### PR TITLE
Permits unsubscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,9 @@ milliseconds (default 500). At most `<n>` events will be sent in each batch
 The `<uuid>` will be used as an HTTP Basic password to the client for
 authentication.
 
-The response is always empty. No side effect if already subscribed.
+The response is always empty. No side effect if already subscribed to a given
+topic.  If a previously subscribed topic is not listed, it will be unsubscribed.
+
 Possible statuses:
 
 - 204: Successfully subscribed to listed topics

--- a/routemaster/controllers/subscription.rb
+++ b/routemaster/controllers/subscription.rb
@@ -1,6 +1,7 @@
 require 'routemaster/controllers'
 require 'routemaster/models/topic'
 require 'routemaster/models/subscription'
+require 'routemaster/services/update_subscription_topics'
 require 'sinatra'
 
 module Routemaster
@@ -37,9 +38,10 @@ module Routemaster
           halt 400
         end
 
-        topics.each do |topic|
-          topic.subscribers.add(sub)
-        end
+        Services::UpdateSubscriptionTopics.new(
+          topics:       topics,
+          subscription: sub,
+        ).call
 
         halt 204
       end

--- a/routemaster/models/subscription.rb
+++ b/routemaster/models/subscription.rb
@@ -66,7 +66,7 @@ module Routemaster::Models
 
     def topics
       Routemaster::Models::Topic.all.select do |t|
-        t.subscribers.map(&:subscriber).include?(self.subscriber)
+        t.subscribers.include?(self)
       end
     end
 
@@ -88,6 +88,10 @@ module Routemaster::Models
 
     def self.each
       _redis.smembers('subscriptions').each { |s| yield new(subscriber: s) }
+    end
+
+    def inspect
+      "<#{self.class.name} name=#{@name}>"
     end
 
     private

--- a/routemaster/models/topic.rb
+++ b/routemaster/models/topic.rb
@@ -71,6 +71,10 @@ module Routemaster
         _redis.hincrby(_key, 'counter', 1)
       end
 
+      def inspect
+        "<#{self.class.name} name=#{@name}>"
+      end
+
       private
 
       def _key

--- a/routemaster/services/update_subscription_topics.rb
+++ b/routemaster/services/update_subscription_topics.rb
@@ -1,0 +1,28 @@
+require 'routemaster/services'
+
+module Routemaster
+  module Services
+    # Update the list of topics subscribed to by a subscribers.
+    # Does _not_ e.g. remove event regarding an unsubscribed topic
+    # from the current queues
+    class UpdateSubscriptionTopics
+      def initialize(subscription:, topics: [])
+        @subscription = subscription
+        @topics = topics
+      end
+      
+      def call
+        # list current topics
+        old_topics = @subscription.topics
+        
+        @topics.reject { |t| old_topics.include?(t) }.each do |topic|
+          topic.subscribers.add(@subscription)
+        end
+
+        old_topics.reject { |t| @topics.include?(t) }.each do |topic|
+          topic.subscribers.remove(@subscription)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/subscribers_spec.rb
+++ b/spec/models/subscribers_spec.rb
@@ -6,8 +6,7 @@ require 'routemaster/models/subscription'
 describe Routemaster::Models::Subscribers do
   Subscription = Routemaster::Models::Subscription
 
-  let(:exchange) { double 'exchange' }
-  let(:topic) { double 'Topic', name: 'widgets', exchange: exchange }
+  let(:topic) { double 'Topic', name: 'widgets' }
   subject { described_class.new(topic) }
 
   describe '#initialize' do
@@ -41,6 +40,57 @@ describe Routemaster::Models::Subscribers do
       subject.add Subscription.new(subscriber: 'bob')
       subject.add Subscription.new(subscriber: 'alice')
       expect(subject.count).to eq(2)
+    end
+  end
+
+  describe '#remove' do
+    before do
+      subject.add Subscription.new(subscriber: 'alice')
+      subject.add Subscription.new(subscriber: 'bob')
+    end
+
+    it 'removes the subscriber' do
+      expect {
+        subject.remove Subscription.new(subscriber: 'bob')
+      }.to change {
+        subject.map(&:subscriber).sort
+      }.from(
+        %w[alice bob]
+      ).to (
+        %w[alice]
+      )
+    end
+
+    it 'works if absent' do
+      expect {
+        subject.remove Subscription.new(subscriber: 'charlie')
+      }.not_to change {
+        subject.map(&:subscriber).sort
+      }
+    end
+  end
+
+  describe '#replace' do
+    let(:names) { subject.map(&:subscriber).sort }
+
+    before do
+      subject.add Subscription.new(subscriber: 'alice')
+      subject.add Subscription.new(subscriber: 'bob')
+    end
+
+    it 'updates subscription list' do
+      expect {
+        subject.replace [
+          Subscription.new(subscriber: 'charlie'),
+          Subscription.new(subscriber: 'alice')
+        ]
+      }.to change {
+        subject.map(&:subscriber).sort
+      }.from(
+        %w[alice bob]
+      ).to(
+        %w[alice charlie]
+      )
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -55,7 +55,7 @@ describe Routemaster::Models::Subscription do
     end
   end
 
-  describe '.topics' do
+  describe '#topics' do
 
     let(:properties_topic) do
       Routemaster::Models::Topic.new(name: 'properties', publisher: 'demo')
@@ -78,7 +78,7 @@ describe Routemaster::Models::Subscription do
     end
   end
 
-  describe '.all_topics_count' do
+  describe '#all_topics_count' do
     let(:properties_topic) do
       Routemaster::Models::Topic.new({
         name: 'properties',

--- a/spec/services/update_subscription_topics_spec.rb
+++ b/spec/services/update_subscription_topics_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'spec/support/persistence'
+require 'routemaster/services/update_subscription_topics'
+require 'routemaster/models/subscription'
+require 'routemaster/models/topic'
+
+describe Routemaster::Services::UpdateSubscriptionTopics do
+  let(:subscription) { Routemaster::Models::Subscription.new(subscriber: 'alice') }
+  let(:topic_a) { Routemaster::Models::Topic.new(name: 'topic_a', publisher: 'bob') }
+  let(:topic_b) { Routemaster::Models::Topic.new(name: 'topic_b', publisher: 'bob') }
+  let(:topic_c) { Routemaster::Models::Topic.new(name: 'topic_c', publisher: 'bob') }
+  let(:topics) { [] }
+
+  subject { described_class.new subscription: subscription, topics: topics }
+
+  def current_topics
+    subscription.topics.map(&:name).sort
+  end
+
+  it 'passes when no topics' do
+    expect { subject.call }.not_to change { current_topics }
+  end
+
+  it 'adds the specified topics' do
+    topics.replace [topic_c, topic_a]
+    expect { subject.call }.to change { current_topics }.from(%w[]).to(%w[topic_a topic_c])
+  end
+
+  context 'when topics already are subscribed' do
+    before do
+      topic_a.subscribers.add subscription
+      topic_b.subscribers.add subscription
+    end
+
+    it 'can remove all subscriptions' do
+      expect { subject.call }.to change { current_topics }.to %w[]
+    end
+
+    it 'can modify the list' do
+      topics.replace [topic_b, topic_c]
+      expect { subject.call }.to change { current_topics }.to %w[topic_b topic_c]
+    end
+
+    it 'can remove from the list' do
+      topics.replace [topic_a]
+      expect { subject.call }.to change { current_topics }.to %w[topic_a]
+    end
+
+    it 'can add to the list' do
+      topics.replace [topic_a, topic_b, topic_c]
+      expect { subject.call }.to change { current_topics }.to %w[topic_a topic_b topic_c]
+    end
+  end
+end


### PR DESCRIPTION
Updates the `POST /subscription` endpoint to permit unsubscription.

Piggybacks on #2 as this is easier to build and test without RabbitMQ.
