### PR TITLE
Catch delivery errors

### DIFF
--- a/spec/integration/single_subscription_spec.rb
+++ b/spec/integration/single_subscription_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'spec/support/persistence'
+require 'spec/support/webmock'
 require 'routemaster/client'
 require 'pathname'
 require 'routemaster/models/subscription'
@@ -128,11 +129,7 @@ describe 'integration' do
 
   Processes = [ServerTunnelProcess, ClientTunnelProcess, WatchProcess, WebProcess, ClientProcess]
 
-  before do
-    if defined?(WebMock)
-      WebMock.disable!
-    end
-  end
+  before { WebMock.disable! }
 
   shared_examples 'start and stop' do
     before { subject.start }

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -3,7 +3,7 @@ require 'routemaster/services/deliver'
 require 'routemaster/models/subscription'
 require 'spec/support/persistence'
 require 'spec/support/events'
-require 'webmock/rspec'
+require 'spec/support/webmock'
 require 'timecop'
 
 
@@ -91,6 +91,14 @@ describe Routemaster::Services::Deliver do
         it 'raises an exception' do
           expect { perform }.to raise_error(described_class::CantDeliver)
         end
+      end
+
+      context 'when the connection fails' do
+        before do
+          allow_any_instance_of(Net::HTTP).to receive(:request).and_raise(SocketError)
+        end
+
+        it { expect { perform }.to raise_error(described_class::CantDeliver) }
       end
     end
 

--- a/spec/support/persistence.rb
+++ b/spec/support/persistence.rb
@@ -3,7 +3,6 @@ require 'singleton'
 require 'faraday'
 require 'rspec'
 require 'uri'
-require 'webmock'
 
 class RedisCleaner
   include Singleton
@@ -16,5 +15,4 @@ end
 
 RSpec.configure do |config|
   config.before(:each) { RedisCleaner.instance.clean! }
-  config.after(:suite) { WebMock.disable! }
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,8 @@
+require 'rspec'
+require 'webmock/rspec'
+
+RSpec.configure do |config|
+  config.before(:each) { WebMock.enable! }
+  config.after(:suite) { WebMock.disable! }
+end
+


### PR DESCRIPTION
Closes #9.

Basically rescues from `Faraday::Error::ClientError`, which occurs on connection failures (can't resolve; can't connect; SSL fail; timeouts).
