### PR TITLE
Messagepack conversion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem 'hiredis'
 gem 'redis', require: %w(redis redis/connection/hiredis)
 gem 'redis-namespace'
 
+# fast, redis-compatible serialisation
+gem 'msgpack'
+
 # talkin' sweet HTTP
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.10)
     method_source (0.8.2)
+    msgpack (1.0.0)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     nenv (0.3.0)
@@ -140,6 +141,7 @@ DEPENDENCIES
   hiredis
   hirefire-resource
   honeybadger
+  msgpack
   newrelic_rpm
   pry
   pry-nav

--- a/core_ext/hash.rb
+++ b/core_ext/hash.rb
@@ -1,0 +1,9 @@
+class Hash
+  def symbolize_keys
+    dup.tap do |h|
+      h.keys.each do |key|
+        h[(key.to_sym rescue key) || key] = h.delete(key)
+      end
+    end
+  end
+end

--- a/routemaster/controllers/topics.rb
+++ b/routemaster/controllers/topics.rb
@@ -1,12 +1,15 @@
 require 'routemaster/controllers'
 require 'routemaster/models/topic'
 require 'routemaster/services/ingest'
+require 'routemaster/mixins/log'
 require 'sinatra'
 require 'json'
 
 module Routemaster
   module Controllers
     class Topics < Sinatra::Base
+      include Routemaster::Mixins::Log
+
       get '/topics' do
         content_type :json
         Routemaster::Models::Topic.all.map do |topic|
@@ -49,6 +52,8 @@ module Routemaster
             timestamp: event_data['timestamp'] || Routemaster.now
           )
         rescue ArgumentError => e
+          _log.warn { "failed to parse event" }
+          _log_exception(e)
           halt 400, 'bad event'
         end
 

--- a/routemaster/controllers/topics.rb
+++ b/routemaster/controllers/topics.rb
@@ -46,9 +46,9 @@ module Routemaster
             topic: params['name'],
             type:  event_data.fetch('type'),
             url:   event_data.fetch('url'),
-            timestamp: event_data.fetch('timestamp', nil)
+            timestamp: event_data['timestamp'] || Routemaster.now
           )
-        rescue ArgumentError
+        rescue ArgumentError => e
           halt 400, 'bad event'
         end
 

--- a/routemaster/models/batch.rb
+++ b/routemaster/models/batch.rb
@@ -39,12 +39,12 @@ module Routemaster
       end
 
       def events
-        @batch.map(&:event)
+        @batch.select { |m| m.kind_of?(Event) }
       end
 
       def age
         now = Routemaster.now
-        @batch.select { |m| m.event? }.map { |m| now - m.event.timestamp }.max || 0
+        @batch.map { |m| now - m.timestamp }.max || 0
       end
 
       private

--- a/routemaster/models/event.rb
+++ b/routemaster/models/event.rb
@@ -1,51 +1,30 @@
 require 'routemaster/models'
 require 'routemaster/models/callback_url'
+require 'routemaster/models/message'
 require 'routemaster/mixins/assert'
 require 'base64'
 
 module Routemaster
   module Models
-    class Event
+    class Event < Message
       include Mixins::Assert
       extend  Mixins::Assert
 
       VALID_TYPES = %w(create update delete noop)
 
-      attr_reader :topic, :type, :url, :timestamp
+      attr_reader :topic, :type, :url
 
-      def initialize(topic:, type:, url:, timestamp: nil)
-        _assert VALID_TYPES.include?(type), 'bad event type'
-        @topic     = topic
-        @type      = type
-        @url       = CallbackURL.new(url)
-        @timestamp = timestamp || Routemaster.now
+      def initialize(**options)
+        super
+        _assert VALID_TYPES.include?(options[:type]), 'bad event type'
+        @topic     = options.fetch(:topic)
+        @type      = options.fetch(:type)
+        @url       = CallbackURL.new options.fetch(:url)
       end
 
-      def marshal_dump
-        [@topic, @type, @url, @timestamp]
+      def to_hash
+        super.merge(topic: @topic, type: @type, url: @url)
       end
-
-      def marshal_load(args)
-        initialize(topic: args[0], type: args[1], url: args[2], timestamp: args[3])
-      end
-
-      def ==(other)
-        other.topic     == topic &&
-        other.type      == type &&
-        other.timestamp == timestamp &&
-        other.url       == url
-      end
-
-      def dump
-        Base64.encode64(Marshal.dump(self))
-      end
-
-      def self.load(data)
-        Marshal.load(Base64.decode64(data)).tap do |event|
-          _assert event.kind_of?(self), 'deserialized data not an Event'
-        end
-      end
-
     end
   end
 end

--- a/routemaster/models/message.rb
+++ b/routemaster/models/message.rb
@@ -12,7 +12,7 @@ module Routemaster
       attr_reader :uid, :timestamp
       
       def initialize(**options)
-        @uid       = options.fetch(:uid) { SecureRandom.uuid }
+        @uid       = options.fetch(:uid) { SecureRandom.hex(16).to_i(16).to_s(36).rjust(25,'0') }
         @timestamp = options.fetch(:timestamp) { Routemaster.now }
         @status    = nil
 

--- a/routemaster/models/message.rb
+++ b/routemaster/models/message.rb
@@ -4,7 +4,7 @@ require 'routemaster/mixins/assert'
 
 module Routemaster
   module Models
-    # Abstract base calss for messages that transits on a queue
+    # Abstract base class for messages that transits on a queue
     class Message
       include Mixins::Log
       include Mixins::Assert

--- a/routemaster/models/message.rb
+++ b/routemaster/models/message.rb
@@ -1,48 +1,51 @@
 require 'routemaster/models'
-require 'routemaster/models/event'
 require 'routemaster/mixins/log'
 require 'routemaster/mixins/assert'
 
 module Routemaster
   module Models
-    # Abstracts a message that transits on a queue
+    # Abstract base calss for messages that transits on a queue
     class Message
       include Mixins::Log
+      include Mixins::Assert
 
-      attr_reader :uid, :payload
+      attr_reader :uid, :timestamp
       
-      def initialize(payload, uid=nil)
-        @uid     = uid || SecureRandom.uuid
-        @payload = payload
-        @status  = nil
+      def initialize(**options)
+        @uid       = options.fetch(:uid) { SecureRandom.uuid }
+        @timestamp = options.fetch(:timestamp) { Routemaster.now }
+        @status    = nil
+
+        _assert @timestamp
       end
 
-      def kill?
-        @payload == 'kill'
-      end
-
-      def ping?
-        @payload == 'ping'
-      end
-
-      def event?
-        !!event
+      def to_hash
+        { timestamp: @timestamp }
       end
 
       def inspect
         "<#{self.class.name} @uid=\"#{@uid}\">"
       end
 
-      def event
-        @event ||= begin
-          Event.load(@payload)
-        rescue ArgumentError, TypeError
-          _log.warn 'bad event payload'
-          nil
-        rescue StandardError => e
-          _log.error { 'unknown error while parsing event' }
-          _log_exception(e)
-          raise
+      # Messages are equal if their _data_ (excluding UID) and timestamps are
+      # equal.
+      def ==(other)
+        to_hash == other.to_hash
+      end
+
+      Kill = Class.new(self)
+      Garbled = Class.new(self)
+
+      class Ping < self
+        attr_reader :data
+
+        def initialize(**options)
+          super(**options)
+          @data = options.fetch(:data, nil)
+        end
+
+        def to_hash
+          super.merge(data: @data)
         end
       end
     end

--- a/routemaster/models/topic.rb
+++ b/routemaster/models/topic.rb
@@ -4,6 +4,7 @@ require 'routemaster/models/user'
 require 'routemaster/models/message'
 require 'routemaster/models/queue'
 require 'routemaster/models/subscribers'
+require 'routemaster/services/codec'
 require 'forwardable'
 
 module Routemaster
@@ -55,12 +56,12 @@ module Routemaster
       def last_event
         raw = _redis.hget(_key, 'last_event')
         return if raw.nil?
-        Event.load(raw)
+        Services::Codec.new.load(raw, nil)
       end
 
       def last_event=(event)
         _assert event.kind_of?(Event), 'can only save Event'
-        _redis.hset(_key, 'last_event', event.dump)
+        _redis.hset(_key, 'last_event', Services::Codec.new.dump(event))
       end
 
       def get_count

--- a/routemaster/services/codec.rb
+++ b/routemaster/services/codec.rb
@@ -1,0 +1,69 @@
+require 'msgpack'
+require 'core_ext/hash'
+require 'routemaster/services'
+require 'routemaster/models/message'
+require 'routemaster/models/event'
+require 'routemaster/mixins/log'
+
+module Routemaster
+  module Services
+    # Encodes and decodes messages so they can be stored in Redis.
+    class Codec
+      include Mixins::Log
+
+      # Produce a Message (or subclass) from a string and a UID
+      def load(data, uid)
+        code, hash = MessagePack.unpack(data)
+        CODE_TO_CLASS[code].new(decode_hash(hash).symbolize_keys.merge(uid: uid))
+      rescue MessagePack::UnpackError => e
+        _log.warn { "Failed to decode message #{uid}" }
+        _log_exception(e)
+        Models::Message::Garbled.new(uid: uid)
+      end
+
+      # Transforms a message into a string
+      def dump(message)
+        [
+          CLASS_TO_CODE[message.class],
+          encode_hash(message.to_hash),
+        ].to_msgpack
+      end
+
+      private
+
+      def encode_hash(hash)
+        transform_hash(KEY_TO_CODE, hash)
+      end
+
+      def decode_hash(hash)
+        transform_hash(CODE_TO_KEY, hash)
+      end
+
+      def transform_hash(map, hash)
+        hash.dup.tap do |h|
+          h.keys.each do |key|
+            h[map[key.to_s]] = h.delete(key)
+          end
+        end
+      end
+
+      CODE_TO_KEY = {
+        't' => 'timestamp',
+        'o' => 'topic',
+        'y' => 'type',
+        'u' => 'url',
+        'd' => 'data',
+      }
+
+      KEY_TO_CODE = Hash[CODE_TO_KEY.to_a.map(&:reverse)]
+
+      CODE_TO_CLASS = {
+        'k' => Models::Message::Kill,
+        'p' => Models::Message::Ping,
+        'e' => Models::Event,
+      }
+
+      CLASS_TO_CODE = Hash[CODE_TO_CLASS.to_a.map(&:reverse)]
+    end
+  end
+end

--- a/routemaster/services/ingest.rb
+++ b/routemaster/services/ingest.rb
@@ -17,8 +17,7 @@ module Routemaster
       end
 
       def call
-        message = Models::Message.new(@event.dump)
-        Models::Queue.push(@topic.subscribers, message)
+        Models::Queue.push(@topic.subscribers, @event)
         @topic.increment_count
         @topic.last_event = @event
         self

--- a/routemaster/services/receive.rb
+++ b/routemaster/services/receive.rb
@@ -35,13 +35,13 @@ module Routemaster
             break count
           end
           
-          if message && message.kill?
+          if message.kind_of?(Models::Message::Kill)
             _log.debug { 'received kill event' }
             @consumer.ack(message)
             raise KillError
           end
 
-          if message.event?
+          if message.kind_of?(Models::Event)
             @batch.push(message)
             _deliver
           else

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'routemaster/application'
 require 'spec/support/rack_test'
 
-describe Routemaster::Application do
+describe Routemaster::Application, type: :controller do
 
   described_class.class_eval do
     get '/fail' do

--- a/spec/controllers/health_spec.rb
+++ b/spec/controllers/health_spec.rb
@@ -3,7 +3,7 @@ require 'routemaster/controllers/health'
 require 'spec/support/rack_test'
 require 'json'
 
-describe Routemaster::Controllers::Health do
+describe Routemaster::Controllers::Health, type: :controller do
   let(:app) { described_class }
   let(:perform) { get '/health/ping' }
 

--- a/spec/controllers/pulse_spec.rb
+++ b/spec/controllers/pulse_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'routemaster/controllers/pulse'
 require 'spec/support/rack_test'
 
-describe Routemaster::Controllers::Pulse do
+describe Routemaster::Controllers::Pulse, type: :controller do
   let(:app) { described_class }
 
   let(:perform) { get '/pulse' }

--- a/spec/controllers/subscription_spec.rb
+++ b/spec/controllers/subscription_spec.rb
@@ -4,7 +4,7 @@ require 'spec/support/rack_test'
 require 'spec/support/persistence'
 require 'json'
 
-describe Routemaster::Controllers::Subscription do
+describe Routemaster::Controllers::Subscription, type: :controller do
   let(:uid) { 'charlie' }
   let(:app) { AuthenticatedApp.new(described_class, uid: uid) }
 

--- a/spec/controllers/topics_spec.rb
+++ b/spec/controllers/topics_spec.rb
@@ -3,7 +3,7 @@ require 'routemaster/controllers/topics'
 require 'spec/support/rack_test'
 require 'spec/support/persistence'
 
-describe Routemaster::Controllers::Topics do
+describe Routemaster::Controllers::Topics, type: :controller do
   let(:uid) { 'joe-user' }
   let(:app) { AuthenticatedApp.new(described_class, uid: uid) }
   let(:topic_name) { 'widgets' }
@@ -35,6 +35,19 @@ describe Routemaster::Controllers::Topics do
         type: 'create',
         url:  'https://example.com/widgets/123',
         timestamp: Time.now.to_f
+      }}
+
+      it 'responds ok' do
+        perform
+        expect(last_response).to be_ok
+      end
+    end
+
+    context 'when supplying a null timestamp' do
+      let(:data) {{
+        type: 'create',
+        url:  'https://example.com/widgets/123',
+        timestamp: nil
       }}
 
       it 'responds ok' do

--- a/spec/core_ext/hash_spec.rb
+++ b/spec/core_ext/hash_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'core_ext/hash'
+
+describe Hash do
+  describe '#symbolize_keys' do
+    it 'leaves {} as is' do
+      expect({}.symbolize_keys).to eq({})
+    end
+
+    it 'returns a copy' do
+      h1 = {'a' => 1}
+      h2 = h1.symbolize_keys
+      h1['a'] = 2
+      expect(h2).to eq(a: 1)
+    end
+
+    it 'transforms keys' do
+      expect({:a => 1, 'b' => 2, 'c' => 3}.symbolize_keys).
+        to eq(a:1, b:2, c:3)
+    end
+  end
+end

--- a/spec/middleware/authentication_spec.rb
+++ b/spec/middleware/authentication_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'routemaster/middleware/authentication'
 require 'spec/support/rack_test'
 
-describe Routemaster::Middleware::Authentication do
+describe Routemaster::Middleware::Authentication, type: :controller do
   class Demo
     def call(env)
       [200, {}, env.fetch('REMOTE_USER', '')]

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+require 'spec/support/events'
+require 'routemaster/models/batch'
+require 'routemaster/models/message'
+
+describe Routemaster::Models::Batch do
+  let(:queue) { double 'queue' }
+  let(:now) { Routemaster.now }
+  let(:events) { [make_event, make_event] }
+  let(:messages) {[
+    Routemaster::Models::Message::Kill.new(timestamp: now - 100),
+    Routemaster::Models::Message::Kill.new(timestamp: now - 300),
+    *events,
+    Routemaster::Models::Message::Kill.new(timestamp: now - 200),
+  ]}
+
+  subject { described_class.new(queue) }
+
+  before do
+    messages.each { |m| subject.push(m) }
+  end
+
+  describe '#length' do
+    it { expect(subject.length).to eq(5) }
+  end
+
+  describe 'acknowledgments' do
+    let(:perform) { subject.public_send(method) }
+    let(:results) { [] }
+
+    shared_examples 'ack-nack' do
+      before do
+        allow(queue).to receive(method) do |msg|
+          results << msg
+        end
+      end
+
+      it 'empties the batch' do
+        expect { perform }.to change { subject.length }.to(0)
+      end
+
+      it 'passes the message to the queue' do
+        perform
+        expect(results).to eq(messages)
+      end
+    end
+
+    describe '#nack' do
+      let(:method) { :nack }
+      include_examples 'ack-nack'
+    end
+
+    describe '#ack' do
+      let(:method) { :ack }
+      include_examples 'ack-nack'
+    end
+  end
+
+  describe '#events' do
+    it 'lists events' do
+      expect(subject.events).to eq(events)
+    end
+  end
+
+  describe '#age' do
+    it 'picks the oldest message' do
+      expect(subject.age).to be_within(50).of(300)
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -29,11 +29,6 @@ describe Routemaster::Models::Event do
       options[:url] = 'https://example.com/widgets/123?wut'
       expect { subject }.to raise_error(ArgumentError)
     end
-
-    it 'adds timestamps' do
-      t = subject.timestamp / 1_000
-      expect(t).to be_within(10).of(Time.now.utc.to_i)
-    end
   end
 
   describe '#==' do

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -2,55 +2,9 @@ require 'spec_helper'
 require 'routemaster/models/message'
 
 describe Routemaster::Models::Message do
-  let(:properties) { double 'properties' }
-  let(:uid) { nil }
-  let(:payload) {
-    Routemaster::Models::Event.new(
-      topic: 'widgets',
-      type:  'create',
-      url:   'https://example.com/widgets/123'
-    ).dump
-  }
+  let(:options) { {} }
 
-  subject { described_class.new(payload, uid) }
-
-  describe '#kill?' do
-    it 'is true when payload is "kill"' do
-      payload.replace 'kill'
-      expect(subject).to be_kill
-    end
-
-    it 'is false otherwise' do
-      expect(subject).not_to be_kill
-    end
-  end
-
-  describe '#event?' do
-    it 'is true for valid event data' do
-      expect(subject).to be_event
-    end
-
-    it 'is false for kill messages' do
-      payload.replace 'kill'
-      expect(subject).not_to be_event
-    end
-
-    it 'is false for gibberish' do
-      payload.replace 'whatever'
-      expect(subject).not_to be_event
-    end
-  end
-
-  describe '#event' do
-    it 'is nil for non-events' do
-      payload.replace 'kill'
-      expect(subject.event).to be_nil
-    end
-
-    it 'returns an Event otherwise' do
-      expect(subject.event).to be_a_kind_of(Routemaster::Models::Event)
-    end
-  end
+  subject { described_class.new(options) }
 
   describe '#uid' do
     it 'is generated' do
@@ -58,10 +12,24 @@ describe Routemaster::Models::Message do
     end
 
     context 'when specified' do
-      let(:uid) { 'abcd-1234' }
+      let(:options) {{ uid: 'abcd-1234' }}
 
       it 'is honoured' do
         expect(subject.uid).to eq('abcd-1234')
+      end
+    end
+  end
+
+  describe '#timestamp' do
+    it 'is generated' do
+      expect(subject.timestamp).to be_within(50).of(Routemaster.now)
+    end
+
+    context 'when specified' do
+      let(:options) {{ timestamp: 1234 }}
+
+      it 'is honoured' do
+        expect(subject.timestamp).to eq(1234)
       end
     end
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -8,7 +8,7 @@ describe Routemaster::Models::Message do
 
   describe '#uid' do
     it 'is generated' do
-      expect(subject.uid).to match /^\h{8}-\h{4}-\h{4}-\h{4}-\h{12}$/
+      expect(subject.uid).to match  /^[a-z0-9]{25}$/
     end
 
     context 'when specified' do

--- a/spec/services/codec_spec.rb
+++ b/spec/services/codec_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'routemaster/services/codec'
+require 'routemaster/models/message'
+require 'routemaster/models/event'
+
+describe Routemaster::Services::Codec do
+  let(:encoded) { subject.dump(message) }
+  let(:decoded) { subject.load(encoded, '1234') }
+
+  shared_examples 'codec' do
+    it 'encodes successfully' do
+      expect { encoded }.not_to raise_error
+    end
+
+    it 'decodes successfully' do
+      expect { decoded }.not_to raise_error
+    end
+
+    it 'is idempotent' do
+      expect(decoded).to eq(message)
+    end
+  end
+
+  context 'with a kill message' do
+    let(:message) { Routemaster::Models::Message::Kill.new }
+    include_examples 'codec'
+  end
+
+  context 'with a ping message' do
+    let(:message) { Routemaster::Models::Message::Ping.new(data: 'foobar') }
+    include_examples 'codec'
+  end
+
+  context 'with an event' do
+    let(:message) {
+      Routemaster::Models::Event.new(
+        topic:      'widgets',
+        type:       'create',
+        url:        'https://example.com/foo/1',
+        timestamp:  12345,
+        uid:        '1234',
+      )
+    }
+    include_examples 'codec'
+  end
+
+  context 'with garbled data' do
+    let(:data) { 'hello' }
+
+    it 'decodes to a "fake" message' do
+      expect(subject.load(data, '1234').uid).to eq('1234')
+    end
+  end
+end

--- a/spec/services/ingest_spec.rb
+++ b/spec/services/ingest_spec.rb
@@ -36,9 +36,9 @@ module Routemaster
 
     it 'pushes to all subscribers' do
       perform
-      expect(consumers[0].pop&.event).to eq(events.first)
-      expect(consumers[1].pop&.event).to be_nil
-      expect(consumers[2].pop&.event).to eq(events.first)
+      expect(consumers[0].pop).to eq(events.first)
+      expect(consumers[1].pop).to be_nil
+      expect(consumers[2].pop).to eq(events.first)
     end
 
     it 'increments the topic event count' do

--- a/spec/services/receive_spec.rb
+++ b/spec/services/receive_spec.rb
@@ -29,11 +29,10 @@ describe Routemaster::Services::Receive do
   end
 
   def make_message(id)
-    event = Routemaster::Models::Event.new(
+    Routemaster::Models::Event.new(
       topic: 'widgets', type: 'create',
       url: "https://example.com/widgets/#{id}",
     )
-    Routemaster::Models::Message.new(event.dump)
   end
 
 
@@ -71,7 +70,7 @@ describe Routemaster::Services::Receive do
 
     context 'when receiving a kill message' do
       let(:messages) {[
-        Routemaster::Models::Message.new('kill')
+        Routemaster::Models::Message::Kill.new
       ]}
 
       it 'acks the message' do
@@ -86,7 +85,7 @@ describe Routemaster::Services::Receive do
 
     context 'when receiving an unknown event' do
       let(:messages) {[
-        Routemaster::Models::Message.new('do you even')
+        Routemaster::Models::Message::Ping.new
       ]}
 
       it 'acks the message' do

--- a/spec/support/rack_test.rb
+++ b/spec/support/rack_test.rb
@@ -8,7 +8,7 @@ class Rack::Test::Session
 end
 
 RSpec.configure do |conf|
-  conf.include Rack::Test::Methods
+  conf.include Rack::Test::Methods, type: :controller
 end
 
 class AuthenticatedApp


### PR DESCRIPTION
- Consolidates `Event` and `Message`: `Event` is now a subclass of `Message` (other types of message can be supported for queue housekeeping, eg. scrubbing in the future)
- Events and messages are now encoded with Messagepack rather than Marshal+Base64 for performance and better memory usage.
- Message UIDs are now Base36 strings instead of hex UUIDs, which save ~30% storage for UID lists.
