### PR TITLE
Redis compatbility

### DIFF
--- a/routemaster/lua/queue_pop.lua
+++ b/routemaster/lua/queue_pop.lua
@@ -8,12 +8,11 @@
 -- ARGV[1]: timestamp of the event
 --
 local uid = redis.call('RPOP', KEYS[1])
-if uid == nil then
+if uid then
+  redis.call('ZADD', KEYS[2], ARGV[1], uid)
+
+  local payload = redis.call('HGET', KEYS[3], uid)
+  return { uid, payload }
+else
   return nil
 end
-
-redis.call('ZADD', KEYS[2], ARGV[1], uid)
-
-local payload = redis.call('HGET', KEYS[3], uid)
-return { uid, payload }
-


### PR DESCRIPTION
With Redis 3.0, RPOP returns `nil` on empty queues; but with in 3.2 `false` is returned.
