### PR TITLE
Drop last-event method

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -50,7 +50,6 @@ All Redis keys are namespaced, under `rm:` by default.
 
   A hash containing metadata has about a topic. Keys:
   - `publisher`: the UUID of the (singly authorized) publisher
-  - `last_event`: a dump of the last event sent
   - `counter`: the cumulative number of events received
 
 `subscribers:{topic}`

--- a/routemaster/lua/queue_pop.lua
+++ b/routemaster/lua/queue_pop.lua
@@ -8,12 +8,11 @@
 -- ARGV[1]: timestamp of the event
 --
 local uid = redis.call('RPOP', KEYS[1])
-if uid == nil then
+if uid then
+  redis.call('ZADD', KEYS[2], ARGV[1], uid)
+
+  local payload = redis.call('HGET', KEYS[3], uid)
+  return { uid, payload }
+else
   return nil
 end
-
-redis.call('ZADD', KEYS[2], ARGV[1], uid)
-
-local payload = redis.call('HGET', KEYS[3], uid)
-return { uid, payload }
-

--- a/routemaster/models/topic.rb
+++ b/routemaster/models/topic.rb
@@ -53,17 +53,6 @@ module Routemaster
         new(name: name, publisher: publisher)
       end
 
-      def last_event
-        raw = _redis.hget(_key, 'last_event')
-        return if raw.nil?
-        Services::Codec.new.load(raw, nil)
-      end
-
-      def last_event=(event)
-        _assert event.kind_of?(Event), 'can only save Event'
-        _redis.hset(_key, 'last_event', Services::Codec.new.dump(event))
-      end
-
       def get_count
         _redis.hget(_key, 'counter').to_i
       end

--- a/routemaster/services/ingest.rb
+++ b/routemaster/services/ingest.rb
@@ -19,7 +19,6 @@ module Routemaster
       def call
         Models::Queue.push(@topic.subscribers, @event)
         @topic.increment_count
-        @topic.last_event = @event
         self
       end
     end

--- a/spec/controllers/topics_spec.rb
+++ b/spec/controllers/topics_spec.rb
@@ -23,11 +23,16 @@ describe Routemaster::Controllers::Topics, type: :controller do
     end
 
     it 'pushes the event' do
+      ingest = double 'ingest'
+      expect(ingest).to receive(:call)
+      expect(Routemaster::Services::Ingest).to receive(:new) { |options|
+        topic = options[:topic]
+        event = options[:event]
+        expect(topic.name).to eq(topic_name)
+        expect(event.type).to eq('create')
+        expect(event.url).to  eq('https://example.com/widgets/123')
+      }.and_return(ingest)
       perform
-      last_event = topic.last_event
-      expect(last_event).not_to be_nil
-      expect(last_event.type).to eq('create')
-      expect(last_event.url).to  eq('https://example.com/widgets/123')
     end
 
     context 'when supplying a timestamp' do

--- a/spec/services/ingest_spec.rb
+++ b/spec/services/ingest_spec.rb
@@ -45,10 +45,5 @@ module Routemaster
       perform
       expect(topic.get_count).to eq(2)
     end
-
-    it 'saves the latest event' do
-      perform
-      expect(topic.last_event).to eq(events.last)
-    end
   end
 end


### PR DESCRIPTION
Drop `Topic#last_event`, which is never used.

(includes #21 because I'm running Redis 3.2 locally now and it's more convenient!)
