### PR TITLE
[IP-370] rename "uuid "delivery token" & "client token"

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ PUMA_TIMEOUT=5
 PUMA_BOOT_TIMEOUT=30
 
 # credentials for allowed clients (comma-separated)
-ROUTEMASTER_CLIENTS=demo
+ROUTEMASTER_CLIENT_TOKENS=demo
 
 # redis server used for metadata & queues
 ROUTEMASTER_REDIS_URL=redis://localhost

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :development do
   gem 'pry-remote'
 
   # testing against the client
-  gem 'routemaster-client', git: 'https://github.com/deliveroo/routemaster-client.git', ref: 'd1dd0f5'
+  gem 'routemaster-client', git: 'https://github.com/deliveroo/routemaster-client.git', ref: '9c5b4a8'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ group :development do
   gem 'pry-remote'
 
   # testing against the client
-  gem 'routemaster-client', git: 'https://github.com/deliveroo/routemaster-client.git', ref: '6f7af94'
+  gem 'routemaster-client', git: 'https://github.com/deliveroo/routemaster-client.git', ref: 'd1dd0f5'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,8 @@ group :development do
   gem 'pry-remote'
 
   # testing against the client
-  gem 'routemaster-client', git: 'https://github.com/deliveroo/routemaster-client.git', ref: '9c5b4a8'
+  gem 'routemaster-client', git: 'https://github.com/deliveroo/routemaster-client.git', ref: '55aa0f6'
+  # gem 'routemaster-client', path: '../routemaster-client'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/deliveroo/routemaster-client.git
-  revision: d1dd0f519cf8ec2098efb04b6d501d4507ff0556
-  ref: d1dd0f5
+  revision: 9c5b4a890943fb981dadda2c067d40bb0a535a75
+  ref: 9c5b4a8
   specs:
     routemaster-client (1.3.1)
       faraday (>= 0.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/deliveroo/routemaster-client.git
-  revision: 9c5b4a890943fb981dadda2c067d40bb0a535a75
-  ref: 9c5b4a8
+  revision: 55aa0f602cd5266bf1235bf1c4b62548ea8d64fa
+  ref: 55aa0f6
   specs:
     routemaster-client (1.3.1)
       faraday (>= 0.9.0)
@@ -67,7 +67,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oj (2.17.5)
+    oj (2.18.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/deliveroo/routemaster-client.git
-  revision: 6f7af94d49f9dc505427265e947289619e33d476
-  ref: 6f7af94
+  revision: d1dd0f519cf8ec2098efb04b6d501d4507ff0556
+  ref: d1dd0f5
   specs:
-    routemaster-client (1.2.2)
+    routemaster-client (1.3.1)
       faraday (>= 0.9.0)
       oj (~> 2.17)
       typhoeus (~> 1.1)
@@ -67,7 +67,7 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    oj (2.17.4)
+    oj (2.17.5)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -173,4 +173,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -55,41 +55,42 @@ All Redis keys are namespaced, under `rm:` by default.
 
 `subscribers`
 
-  The set of all subscriber UUIDs.
+  The set of all subscriber client tokens.
 
-`topics:{subscriber.name}`
+`topics:{client_token}`
 
-  The set of topic names subscribed to by subscriber `name`.
+  The set of topic names subscribed to by subscriber `client_token`.
 
 `subscribers:{topic}`
 
-  The set of subscriber UUIDs having subscribed to topic `name`.
+  The set of subscriber client tokens having subscribed to topic `name`.
 
-`topic:{topic.name}`
+`topic:{name}`
 
   A hash containing metadata has about a topic. Keys:
-  - `publisher`: the UUID of the (singly authorized) publisher
+  - `publisher`: the client token of the (singly authorized) publisher
   - `counter`: the cumulative number of events received
 
-`subscriber:{subscriber.name}`
+`subscriber:{client_token}`
 
   A hash of subscription medatata. Keys:
   - `callback`: the URL to send events to.
   - `timeout`: how long to defer event delivery for batching purposes.
   - `max_events`: maximum number of events to batch.
-  - `delivery_token`: the credential to use when delivering events.
+  - `callback_token`: the credential to use when delivering events.
 
-`queue:new:{subscriber}`
+`queue:new:{client_token}`
 
-  A list of UIDs of messages to be delivered, in reception order.
+  A list of UIDs of messages to be delivered, in reception order, by subscriber
+  client token.
 
-`queue:pending:{subscriber}`
+`queue:pending:{client_token}`
 
   A zset of UIDs of messages for which delivery is in progress, keyed by the
   timestamp of the attempt.
   This gets cleared when messages are acked or nacked.
 
-`queue:data:{subscriber}`
+`queue:data:{client_token}`
 
   A hash of messages keyed by their UID. Includes new and unacked messages.
 

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -57,27 +57,27 @@ All Redis keys are namespaced, under `rm:` by default.
 
   The set of all subscriber UUIDs.
 
-`topics:{uuid}`
+`topics:{subscriber.name}`
 
-  The set of topic names subscribed to by subscriber `uuid`.
+  The set of topic names subscribed to by subscriber `name`.
 
 `subscribers:{topic}`
 
   The set of subscriber UUIDs having subscribed to topic `name`.
 
-`topic:{name}`
+`topic:{topic.name}`
 
   A hash containing metadata has about a topic. Keys:
   - `publisher`: the UUID of the (singly authorized) publisher
   - `counter`: the cumulative number of events received
 
-`subscriber:{uuid}`
+`subscriber:{subscriber.name}`
 
   A hash of subscription medatata. Keys:
   - `callback`: the URL to send events to.
   - `timeout`: how long to defer event delivery for batching purposes.
   - `max_events`: maximum number of events to batch.
-  - `uuid`: the credential to use when delivering events.
+  - `delivery_token`: the credential to use when delivering events.
 
 `queue:new:{subscriber}`
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ satisfactory to us; either they're too complex to host and maintain, don't
 support key features (persistence), or provide too much rope to hang ourselves
 with.
 
-### Remote procedure call as an antipattern
+### Remote procedure call as an anti-pattern
 
 Routemaster is designed on purpose to _not_ support RPC-style architectures, for
 instance by severely limiting payload contents.
@@ -116,8 +116,8 @@ variable.
 By default the bus will send events to `demo`, eg:
 
 ```
-# Allowed UUIDs, separated by commas
-ROUTEMASTER_CLIENTS=demo,my-service--6f1d6311-98a9-42ab-8da4-ed2d7d5b86c4`
+# Allowed Client UUIDs, separated by commas
+ROUTEMASTER_CLIENT_UUIDS=demo,my-service--6f1d6311-98a9-42ab-8da4-ed2d7d5b86c4`
 ```
 
 For further configuration options please check the provided `.env` files
@@ -214,7 +214,7 @@ Redis, in bytes
 
 Set `ROUTEMASTER_REDIS_MIN_MEM` to the threshold, in bytes (10MB by default). If
 less than this value is free, the auto-dropper will remove messages until twice
-the treshold in free memory is available.
+the threshold in free memory is available.
 
 The auto-dropper runs every 30 seconds.
 
@@ -252,7 +252,7 @@ HTTP Basic is required for all requests. The username is stored as a
 human-readable name (but not checked); the password should be a per-client UUID.
 
 The list of allowed clients is part of the configuration, and is passed as a
-comma-separated list to the `ROUTEMASTER_CLIENTS` environment variable.
+comma-separated list to the `ROUTEMASTER_CLIENT_UUIDS` environment variable.
 
 
 ### Publication (creating topics)

--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ A subscriber can "catch up" event if it hasn't pulled events for a while
 ## Installing & Configuring
 
 In order to have routemaster receive connections from a receiver or emitter
-you'll need to add their identifier to the `ROUTEMASTER_CLIENTS` environment
-variable.
+you'll need to add their identifier to the `ROUTEMASTER_CLIENT_TOKENS`
+environment variable.
 
 By default the bus will send events to `demo`, eg:
 
 ```
-# Allowed Client UUIDs, separated by commas
-ROUTEMASTER_CLIENT_UUIDS=demo,my-service--6f1d6311-98a9-42ab-8da4-ed2d7d5b86c4`
+# Allowed client tokens, separated by commas
+ROUTEMASTER_CLIENT_TOKENS=demo,my-service--6f1d6311-98a9-42ab-8da4-ed2d7d5b86c4`
 ```
 
 For further configuration options please check the provided `.env` files
@@ -249,10 +249,11 @@ The auto-dropper runs every 30 seconds.
 All requests over non-SSL connections will be met with a 308 Permanent Redirect.
 
 HTTP Basic is required for all requests. The username is stored as a
-human-readable name (but not checked); the password should be a per-client UUID.
+human-readable name (but not checked); the password should be a per-client
+client.
 
 The list of allowed clients is part of the configuration, and is passed as a
-comma-separated list to the `ROUTEMASTER_CLIENT_UUIDS` environment variable.
+comma-separated list to the `ROUTEMASTER_CLIENT_TOKENS` environment variable.
 
 
 ### Publication (creating topics)
@@ -307,9 +308,9 @@ A client can therefore only obtain events from their own subscription.
 
     >> POST /subscription
     >> {
-    >>   topics:   [<name>, ...],
-    >>   callback: <url>,
-    >>   uuid:     <uuid>,
+    >>   topics:          [<name>, ...],
+    >>   callback:        <url>,
+    >>   callback_token:  <secret>,
     >>   timeout:  <t>,
     >>   max:      <n>
     >> ]
@@ -318,7 +319,7 @@ Subscribes the client to receive events from the named topics. When events are
 ready, they will be POSTed to the `<url>` (see below), at most every `<t>`
 milliseconds (default 500). At most `<n>` events will be sent in each batch
 (default 100).
-The `<uuid>` will be used as an HTTP Basic password to the client for
+The `<secret>` will be used as an HTTP Basic password to the client for
 authentication.
 
 The response is always empty. No side effect if already subscribed to a given
@@ -418,7 +419,8 @@ Routermaster provides monitoring endpoints:
 - `<oldest>`: timestamp (seconds since epoch) of the oldest pending event.
 
 
-Monitoring resources can be queries by clients with a UUID included in `ROUTEMASTER_MONITORS`.
+Monitoring resources can be queries by clients with a token included in
+`ROUTEMASTER_MONITORS`.
 
 Routemaster does not, and will not include an UI for monitoring, as that would
 complexify its codebase too much (it's a separate concern, really).

--- a/routemaster/controllers/subscriber.rb
+++ b/routemaster/controllers/subscriber.rb
@@ -10,7 +10,7 @@ module Routemaster
     class Subscriber < Sinatra::Base
       register Parser
 
-      VALID_KEYS = %w(topics callback delivery_token uuid max timeout)
+      VALID_KEYS = %w(topics callback callback_token uuid max timeout)
 
       post %r{^/(subscription|subscriber)$}, parse: :json do
         if (data.keys - VALID_KEYS).any?
@@ -28,15 +28,14 @@ module Routemaster
         halt 404 unless topics.all?
 
         if data.has_key?('uuid')
-          warn "received uuid in payload - this is deprecated & renamed delivery_token"
-
-          data['delivery_token'] = data.delete('uuid')
+          warn "received uuid in payload - this is deprecated & renamed calback_token"
+          data['callback_token'] = data.delete('uuid')
         end
 
         begin
           sub = Models::Subscriber.new(name: request.env['REMOTE_USER'])
           sub.callback       = data['callback']
-          sub.delivery_token = data['delivery_token']
+          sub.callback_token = data['callback_token']
           sub.timeout        = data['timeout'] if data['timeout']
           sub.max_events     = data['max']     if data['max']
         rescue ArgumentError => e

--- a/routemaster/controllers/subscriber.rb
+++ b/routemaster/controllers/subscriber.rb
@@ -10,7 +10,7 @@ module Routemaster
     class Subscriber < Sinatra::Base
       register Parser
 
-      VALID_KEYS = %w(topics callback uuid max timeout)
+      VALID_KEYS = %w(topics callback delivery_token max timeout)
 
       post %r{^/(subscription|subscriber)$}, parse: :json do
         if (data.keys - VALID_KEYS).any?
@@ -29,10 +29,10 @@ module Routemaster
 
         begin
           sub = Models::Subscriber.new(name: request.env['REMOTE_USER'])
-          sub.callback   = data['callback']
-          sub.uuid       = data['uuid']
-          sub.timeout    = data['timeout'] if data['timeout']
-          sub.max_events = data['max']     if data['max']
+          sub.callback       = data['callback']
+          sub.delivery_token = data['delivery_token']
+          sub.timeout        = data['timeout'] if data['timeout']
+          sub.max_events     = data['max']     if data['max']
         rescue ArgumentError => e
           halt 400, e.message
         end

--- a/routemaster/controllers/subscriber.rb
+++ b/routemaster/controllers/subscriber.rb
@@ -10,7 +10,7 @@ module Routemaster
     class Subscriber < Sinatra::Base
       register Parser
 
-      VALID_KEYS = %w(topics callback delivery_token max timeout)
+      VALID_KEYS = %w(topics callback delivery_token uuid max timeout)
 
       post %r{^/(subscription|subscriber)$}, parse: :json do
         if (data.keys - VALID_KEYS).any?
@@ -26,6 +26,12 @@ module Routemaster
           Models::Topic.new(name: name, publisher: nil)
         end
         halt 404 unless topics.all?
+
+        if data.has_key?('uuid')
+          warn "received uuid in payload - this is deprecated & renamed delivery_token"
+
+          data['delivery_token'] = data.delete('uuid')
+        end
 
         begin
           sub = Models::Subscriber.new(name: request.env['REMOTE_USER'])

--- a/routemaster/middleware/authentication.rb
+++ b/routemaster/middleware/authentication.rb
@@ -20,7 +20,8 @@ module Routemaster
 
       def _tokens
         return @_tokens if @_tokens
-        if raw = ENV['ROUTEMASTER_CLIENTS']
+        raw = ENV['ROUTEMASTER_CLIENTS']
+        if raw
           warn 'ROUTEMASTER_CLIENTS is deprecated, use ROUTEMASTER_CLIENT_TOKENS'
         else
           raw = ENV.fetch('ROUTEMASTER_CLIENT_TOKENS', '')

--- a/routemaster/middleware/authentication.rb
+++ b/routemaster/middleware/authentication.rb
@@ -16,7 +16,7 @@ module Routemaster
 
       def _authenticate(username, password)
         @_users ||= Set.new(
-          ENV.fetch('ROUTEMASTER_CLIENTS', '').split(','))
+          ENV.fetch('ROUTEMASTER_CLIENT_UUIDS', '').split(','))
         !! @_users.include?(username)
       end
     end

--- a/routemaster/middleware/authentication.rb
+++ b/routemaster/middleware/authentication.rb
@@ -15,9 +15,18 @@ module Routemaster
       private
 
       def _authenticate(username, password)
-        @_users ||= Set.new(
-          ENV.fetch('ROUTEMASTER_CLIENT_UUIDS', '').split(','))
-        !! @_users.include?(username)
+        _tokens.include?(username)
+      end
+
+      def _tokens
+        return @_tokens if @_tokens
+        if raw = ENV['ROUTEMASTER_CLIENTS']
+          warn 'ROUTEMASTER_CLIENTS is deprecated, use ROUTEMASTER_CLIENT_TOKENS'
+        else
+          raw = ENV.fetch('ROUTEMASTER_CLIENT_TOKENS', '')
+        end
+        
+        @_tokens = Set.new(raw.split(','))
       end
     end
   end

--- a/routemaster/models/subscriber.rb
+++ b/routemaster/models/subscriber.rb
@@ -57,13 +57,13 @@ module Routemaster::Models
       raw.to_i
     end
 
-    def uuid=(value)
+    def delivery_token=(value)
       _assert value.kind_of?(String) unless value.nil?
-      _redis.hset(_key, 'uuid', value)
+      _redis.hset(_key, 'delivery_token', value)
     end
 
-    def uuid
-      _redis.hget(_key, 'uuid')
+    def delivery_token
+      _redis.hget(_key, 'delivery_token')
     end
 
     def to_s

--- a/routemaster/models/subscriber.rb
+++ b/routemaster/models/subscriber.rb
@@ -57,13 +57,13 @@ module Routemaster::Models
       raw.to_i
     end
 
-    def delivery_token=(value)
+    def callback_token=(value)
       _assert value.kind_of?(String) unless value.nil?
-      _redis.hset(_key, 'delivery_token', value)
+      _redis.hset(_key, 'callback_token', value)
     end
 
-    def delivery_token
-      _redis.hget(_key, 'delivery_token')
+    def callback_token
+      _redis.hget(_key, 'callback_token')
     end
 
     def to_s

--- a/routemaster/services/deliver.rb
+++ b/routemaster/services/deliver.rb
@@ -72,7 +72,7 @@ module Routemaster
       def _conn
         @_conn ||= Faraday.new(@subscriber.callback, ssl: { verify: _verify_ssl? }) do |c|
           c.adapter :typhoeus
-          c.basic_auth(@subscriber.uuid, 'x')
+          c.basic_auth(@subscriber.delivery_token, 'x')
           c.options[:open_timeout] = CONNECT_TIMEOUT
           c.options[:timeout] = TIMEOUT
         end

--- a/routemaster/services/deliver.rb
+++ b/routemaster/services/deliver.rb
@@ -72,7 +72,7 @@ module Routemaster
       def _conn
         @_conn ||= Faraday.new(@subscriber.callback, ssl: { verify: _verify_ssl? }) do |c|
           c.adapter :typhoeus
-          c.basic_auth(@subscriber.delivery_token, 'x')
+          c.basic_auth(@subscriber.callback_token, 'x')
           c.options[:open_timeout] = CONNECT_TIMEOUT
           c.options[:timeout] = TIMEOUT
         end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -17,7 +17,7 @@ describe Routemaster::Application, type: :controller do
   describe 'unknown endpoint' do
 
     before do
-      ENV['ROUTEMASTER_CLIENTS'] = 'demo'
+      ENV['ROUTEMASTER_CLIENT_TOKENS'] = 'demo'
       authorize 'demo', 'x'
     end
 

--- a/spec/controllers/subscriber_spec.rb
+++ b/spec/controllers/subscriber_spec.rb
@@ -59,9 +59,9 @@ describe Routemaster::Controllers::Subscriber, type: :controller do
 
   describe 'post /subscriber' do
     let(:payload) {{
-      topics:   %w(widgets),
+      topics: %w(widgets),
       callback: 'https://app.example.com/events',
-      uuid:     'alice'
+      delivery_token: 'alice'
     }}
     let(:raw_payload) { payload.to_json }
     let(:perform) do
@@ -114,9 +114,9 @@ describe Routemaster::Controllers::Subscriber, type: :controller do
       expect(subscriber.callback).to eq('https://app.example.com/events')
     end
 
-    it 'sets the subscriber uuid' do
+    it 'sets the subscriber delivery_token' do
       perform
-      expect(subscriber.uuid).to eq('alice')
+      expect(subscriber.delivery_token).to eq('alice')
     end
 
     it 'sets the subscriber timeout' do

--- a/spec/controllers/subscriber_spec.rb
+++ b/spec/controllers/subscriber_spec.rb
@@ -59,9 +59,9 @@ describe Routemaster::Controllers::Subscriber, type: :controller do
 
   describe 'post /subscriber' do
     let(:payload) {{
-      topics: %w(widgets),
-      callback: 'https://app.example.com/events',
-      delivery_token: 'alice'
+      topics:         %w(widgets),
+      callback:       'https://app.example.com/events',
+      callback_token: 'alice'
     }}
     let(:raw_payload) { payload.to_json }
     let(:perform) do
@@ -114,9 +114,15 @@ describe Routemaster::Controllers::Subscriber, type: :controller do
       expect(subscriber.callback).to eq('https://app.example.com/events')
     end
 
-    it 'sets the subscriber delivery_token' do
+    it 'sets the subscriber callback_token' do
       perform
-      expect(subscriber.delivery_token).to eq('alice')
+      expect(subscriber.callback_token).to eq('alice')
+    end
+
+    it 'accepts the deprecated uuid in place of callback_token' do
+      payload[:uuid] = payload.delete(:callback_token)
+      perform
+      expect(subscriber.callback_token).to eq('alice')
     end
 
     it 'sets the subscriber timeout' do

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -18,7 +18,7 @@ describe 'Client integration' do
   after  { client_processes.each { |c| c.wait_stop } }
   after  { client_processes.each { |c| c.stop } }
 
-  let(:client) { Routemaster::Client.new(url: 'https://127.0.0.1:17893', delivery_token: 'demo', verify_ssl: false) }
+  let(:client) { Routemaster::Client.new(url: 'https://127.0.0.1:17893', client_token: 'demo', verify_ssl: false) }
   let(:subscriber) { Routemaster::Models::Subscriber.find('demo') }
   let(:topic) { Routemaster::Models::Topic.find('widgets') }
   let(:queue) { subscriber.queue }

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -18,7 +18,7 @@ describe 'Client integration' do
   after  { client_processes.each { |c| c.wait_stop } }
   after  { client_processes.each { |c| c.stop } }
 
-  let(:client) { Routemaster::Client.new(url: 'https://127.0.0.1:17893', uuid: 'demo', verify_ssl: false) }
+  let(:client) { Routemaster::Client.new(url: 'https://127.0.0.1:17893', delivery_token: 'demo', verify_ssl: false) }
   let(:subscriber) { Routemaster::Models::Subscriber.find('demo') }
   let(:topic) { Routemaster::Models::Topic.find('widgets') }
   let(:queue) { subscriber.queue }
@@ -62,7 +62,7 @@ describe 'Client integration' do
       client.unsubscribe('widgets')
       expect(subscriber.topics.map(&:name)).not_to include('widgets')
     end
-    
+
     it 'unsubscribes entirely' do
       client.unsubscribe_all
       expect(subscriber).to be_nil

--- a/spec/integration/delivery_spec.rb
+++ b/spec/integration/delivery_spec.rb
@@ -14,7 +14,7 @@ describe 'Event delivery', type: :acceptance do
   after  { processes.all.each { |p| p.stop } }
 
   let(:client) {
-    Routemaster::Client.new(url: 'https://127.0.0.1:17893', delivery_token: 'demo', verify_ssl: false)
+    Routemaster::Client.new(url: 'https://127.0.0.1:17893', client_token: 'demo', verify_ssl: false)
   }
   let(:max_events) { '1' }
   let(:timeout) { '0' }
@@ -27,11 +27,11 @@ describe 'Event delivery', type: :acceptance do
     client.created('dogs', 'https://example.com/dogs/1')
 
     client.subscribe(
-      topics:   %w(cats dogs),
-      callback: 'https://127.0.0.1:17894/events',
-      uuid:     'demo-client',
-      max:      Integer(max_events),
-      timeout:  Integer(timeout)
+      topics:         %w(cats dogs),
+      callback:       'https://127.0.0.1:17894/events',
+      callback_token: 'demo-client',
+      max:            Integer(max_events),
+      timeout:        Integer(timeout)
     )
   end
 

--- a/spec/integration/delivery_spec.rb
+++ b/spec/integration/delivery_spec.rb
@@ -14,7 +14,7 @@ describe 'Event delivery', type: :acceptance do
   after  { processes.all.each { |p| p.stop } }
 
   let(:client) {
-    Routemaster::Client.new(url: 'https://127.0.0.1:17893', uuid: 'demo', verify_ssl: false)
+    Routemaster::Client.new(url: 'https://127.0.0.1:17893', delivery_token: 'demo', verify_ssl: false)
   }
   let(:max_events) { '1' }
   let(:timeout) { '0' }

--- a/spec/middleware/authentication_spec.rb
+++ b/spec/middleware/authentication_spec.rb
@@ -31,7 +31,7 @@ describe Routemaster::Middleware::Authentication, type: :controller do
   end
 
   context 'with proper credentials' do
-    before { ENV['ROUTEMASTER_CLIENTS'] = 'bob,john-mcfoo' }
+    before { ENV['ROUTEMASTER_CLIENT_UUIDS'] = 'bob,john-mcfoo' }
     before { authorize 'john-mcfoo', 'secret' }
 
     it 'succeeds' do

--- a/spec/middleware/authentication_spec.rb
+++ b/spec/middleware/authentication_spec.rb
@@ -31,17 +31,28 @@ describe Routemaster::Middleware::Authentication, type: :controller do
   end
 
   context 'with proper credentials' do
-    before { ENV['ROUTEMASTER_CLIENT_UUIDS'] = 'bob,john-mcfoo' }
     before { authorize 'john-mcfoo', 'secret' }
 
-    it 'succeeds' do
-      perform
-      expect(last_response).to be_ok
+    shared_examples 'checks' do
+      it 'succeeds' do
+        perform
+        expect(last_response).to be_ok
+      end
+
+      it 'returns the username' do
+        perform
+        expect(last_response.body).to eq('john-mcfoo')
+      end
     end
 
-    it 'returns the username' do
-      perform
-      expect(last_response.body).to eq('john-mcfoo')
+    context 'using ROUTEMASTER_CLIENTS' do
+      before { ENV['ROUTEMASTER_CLIENTS'] = 'bob,john-mcfoo' }
+      include_examples 'checks' 
+    end
+
+    context 'using ROUTEMASTER_CLIENT_TOKENS' do
+      before { ENV['ROUTEMASTER_CLIENT_TOKENS'] = 'bob,john-mcfoo' }
+      include_examples 'checks' 
     end
   end
 end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -21,7 +21,7 @@ describe Routemaster::Models::Subscriber do
 
     let(:perform) do
       subject.callback = 'https://example.com'
-      subject.delivery_token = '0e959830-6de3-11e6-8b8f-572d810770de'
+      subject.callback_token = '0e959830-6de3-11e6-8b8f-572d810770de'
       Routemaster::Models::Subscription.new(topic: topic, subscriber: subject).save
       subject.destroy
     end

--- a/spec/models/subscriber_spec.rb
+++ b/spec/models/subscriber_spec.rb
@@ -21,7 +21,7 @@ describe Routemaster::Models::Subscriber do
 
     let(:perform) do
       subject.callback = 'https://example.com'
-      subject.uuid = '0e959830-6de3-11e6-8b8f-572d810770de'
+      subject.delivery_token = '0e959830-6de3-11e6-8b8f-572d810770de'
       Routemaster::Models::Subscription.new(topic: topic, subscriber: subject).save
       subject.destroy
     end
@@ -32,7 +32,7 @@ describe Routemaster::Models::Subscriber do
 
     it 'removes' do
       perform
-      expect(described_class.find('alice')).to be_nil 
+      expect(described_class.find('alice')).to be_nil
     end
 
     it 'cleans up' do

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -16,7 +16,7 @@ describe Routemaster::Services::Deliver do
 
   before do
     WebMock.enable!
-    subscriber.uuid = 'hello'
+    subscriber.delivery_token = 'hello'
     subscriber.callback = callback
   end
 

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -16,7 +16,7 @@ describe Routemaster::Services::Deliver do
 
   before do
     WebMock.enable!
-    subscriber.delivery_token = 'hello'
+    subscriber.callback_token = 'hello'
     subscriber.callback = callback
   end
 

--- a/spec/support/client.ru
+++ b/spec/support/client.ru
@@ -16,9 +16,9 @@ class App
 end
 
 use Routemaster::Receiver, {
-  path:    '/events',
-  uuid:    'demo-client',
-  handler: Handler.new
+  path:           '/events',
+  delivery_token: 'demo-client',
+  handler:        Handler.new
 }
 
 run App

--- a/spec/support/client.ru
+++ b/spec/support/client.ru
@@ -17,7 +17,7 @@ end
 
 use Routemaster::Receiver, {
   path:           '/events',
-  delivery_token: 'demo-client',
+  callback_token: 'demo-client',
   handler:        Handler.new
 }
 


### PR DESCRIPTION
* Renamed `Subscriber#uuid` to `Subscriber#callback_token` to accurately reflect its purpose
* Renamed the `ROUTEMASTER_CLIENTS` environment variable to `ROUTEMASTER_CLIENT_TOKENS` 
* Improved docs on internal Redis keys

[Read more on JIRA!](https://deliveroo.atlassian.net/browse/IP-370)