### PR TITLE
IP-448: Configuration cloning

### DIFF
--- a/routemaster/controllers/subscription.rb
+++ b/routemaster/controllers/subscription.rb
@@ -62,6 +62,7 @@ module Routemaster::Controllers
       payload = Routemaster::Models::Subscription.map do |subscription|
         {
           subscriber: subscription.subscriber,
+          uuid:   subscription.uuid,
           callback: subscription.callback,
           topics: subscription.topics.map(&:name),
           events: {

--- a/spec/controllers/subscription_spec.rb
+++ b/spec/controllers/subscription_spec.rb
@@ -20,7 +20,10 @@ describe Routemaster::Controllers::Subscription do
     let(:subscription) do
       Routemaster::Models::Subscription.new(
         subscriber: 'charlie'
-      )
+      ).tap do |sub|
+        sub.callback = 'https://example.com/events'
+        sub.uuid = 's3cr3t'
+      end
     end
 
     let(:perform) { get "/subscriptions" }
@@ -47,7 +50,8 @@ describe Routemaster::Controllers::Subscription do
       expect(resp)
         .to eql([{
           "subscriber" => "charlie",
-          "callback"   => nil,
+          "callback"   => 'https://example.com/events',
+          'uuid'       => 's3cr3t',
           "topics"     => ["widget"],
           "events"     => {
             "sent"   => 100,

--- a/spec/support/persistence.rb
+++ b/spec/support/persistence.rb
@@ -4,6 +4,7 @@ require 'singleton'
 require 'faraday'
 require 'rspec'
 require 'uri'
+require 'webmock'
 
 class RedisCleaner
   include Singleton


### PR DESCRIPTION
This PR exposes the publisher callback credentials in the `/subscriptions` endpoint.
The aim is to allow another instance of the bus to import subscriptions (during upgrades).

This is to be merged into v1 (then ported forward).

===

Jira story [#IP-448](https://deliveroo.atlassian.net/browse/IP-448) in project *Infrastructure and Platform*:

> ## Why
> 
> Deploying a new version of the bus requires 2 busses to coexist for a short while and have identical subscription configuration.
> 
> Rationale:
> To upgrade the bus, and not lose events, a precondition is that subscriptions are set up _before_ any event is published on the new bus.
> This cannot be achieved through a careful restart sequence of services because publishers can be subscribers too.
> 
> ## What
> 
> - Add an endpoint to dump subscription configuration
> - Add an endpoint to import subscription configuration (from the dump endpoint, given another bus's URL)