### PR TITLE
IP-452: Handle NOSCRIPT

### DIFF
--- a/routemaster/lua/sum.lua
+++ b/routemaster/lua/sum.lua
@@ -1,0 +1,11 @@
+--
+-- Dummy script for testing purposes
+--
+-- Returns sum of the arguments it was passed
+--
+
+local result = 0
+for k,v in pairs(ARGV) do
+  result = result + tonumber(v)
+end
+return result

--- a/routemaster/mixins/redis.rb
+++ b/routemaster/mixins/redis.rb
@@ -29,6 +29,10 @@ module Routemaster
       def _redis_lua_run(script_name, keys:nil, argv:nil)
         sha = _redis_lua_sha(script_name)
         _redis.evalsha(sha, keys: keys, argv: argv)
+      rescue ::Redis::CommandError => e
+        raise unless /NOSCRIPT/ =~ e.message
+        @@_redis_lua_sha.delete script_name
+        retry
       end
     end
   end

--- a/spec/mixins/redis_spec.rb
+++ b/spec/mixins/redis_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'spec/support/persistence'
+require 'routemaster/mixins/redis'
+
+describe Routemaster::Mixins::Redis do
+  include described_class
+
+  describe '#_redis_lua_run' do
+    def perform
+      _redis_lua_run('sum', argv:[2,3,4])
+    end
+
+    it 'runs named scripts' do
+      expect(perform).to eq(9)
+    end
+
+    context 'when scripts gets flushed' do
+      before do
+        perform
+        _redis.script('flush')
+      end
+
+      it { expect { perform }.not_to raise_error }
+    end
+  end
+end


### PR DESCRIPTION
Whenever `EVALSHA` returns a missing script error, reload the script.

===

Jira story [#IP-452](https://deliveroo.atlassian.net/browse/IP-452) in project *Infrastructure and Platform*:

> ## Why
> 
> Lua script status isn't persisted in Redis, so reboots/switching to replicas causes EVALSHA to raise NOSCRIPT.
> 
> !https://www.dropbox.com/s/visdsuwnk7z142z/Screenshot%202017-01-13%2009.09.52.png?raw=1|width=360!
> 
> ## What
> 
> Make our Lua script execution robust to scripts being removed.