### PR TITLE
IP-466: Dyno crash can block delivery

### DIFF
--- a/bin/worker
+++ b/bin/worker
@@ -5,6 +5,7 @@ require 'routemaster/models/counters'
 require 'routemaster/services/thread_group'
 require 'routemaster/services/worker'
 require 'routemaster/services/ticker'
+require 'routemaster/services/scheduler'
 require 'routemaster/mixins/log'
 
 include Routemaster::Mixins::Log
@@ -17,10 +18,10 @@ Routemaster.configure(
 
 _log.info { 'creating thread group' }
 Routemaster::Services::ThreadGroup.new.tap do |group|
+  # job promoter
+  group.add Routemaster::Services::Scheduler.new, name: 'scheduler'
+
   # ticker threads
-  group.add Routemaster::Services::Ticker.new(
-    queue: Routemaster.aux_queue, name: 'schedule', every: 100, delay: false
-  ), name: 'ticker.schedule'
   group.add Routemaster::Services::Ticker.new(
     queue: Routemaster.aux_queue, name: 'autodrop', every: 10_000
   ), name: 'ticker.autodrop'

--- a/routemaster/models/job.rb
+++ b/routemaster/models/job.rb
@@ -3,7 +3,7 @@ require 'routemaster/mixins/redis'
 require 'msgpack'
 require 'core_ext/string'
 
-%w[autodrop batch monitor schedule scrub_queues scrub_workers].each do |name|
+%w[autodrop batch monitor scrub_queues scrub_workers].each do |name|
   require "routemaster/jobs/#{name}"
 end
 

--- a/routemaster/services/scheduler.rb
+++ b/routemaster/services/scheduler.rb
@@ -1,18 +1,27 @@
-require 'routemaster/jobs'
+require 'routemaster/services'
 require 'routemaster/models/queue'
 require 'routemaster/mixins/log'
 
 module Routemaster
-  module Jobs
-    class Schedule
+  module Services
+    class Scheduler
       include Mixins::Log
 
       def call
+        next_at = Routemaster.now + INTERVAL
+
         Models::Queue.each do |q|
           jobs = q.schedule
           _log.debug { "scheduler: promoted #{jobs} jobs on queue.#{q.name}" }
         end
+
+        sleep TICK while (block_given? ? yield : true) && Routemaster.now < next_at
       end
+
+      private
+
+      TICK = 10e-3
+      INTERVAL = 100 # schedule jobs every X ms
     end
   end
 end

--- a/routemaster/services/scheduler.rb
+++ b/routemaster/services/scheduler.rb
@@ -7,6 +7,9 @@ module Routemaster
     class Scheduler
       include Mixins::Log
 
+      TICK = 10e-3
+      INTERVAL = 100 # schedule jobs every this many milliseconds
+
       def call
         next_at = Routemaster.now + INTERVAL
 
@@ -17,11 +20,6 @@ module Routemaster
 
         sleep TICK while (block_given? ? yield : true) && Routemaster.now < next_at
       end
-
-      private
-
-      TICK = 10e-3
-      INTERVAL = 100 # schedule jobs every X ms
     end
   end
 end

--- a/spec/services/scheduler_spec.rb
+++ b/spec/services/scheduler_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'routemaster/jobs/schedule'
+require 'routemaster/services/scheduler'
 
-describe Routemaster::Jobs::Schedule do
+describe Routemaster::Services::Scheduler do
   it 'performs scheduling on each queue' do
     q1 = double name: 'q1'
     q2 = double name: 'q2'


### PR DESCRIPTION
This makes promotion of jobs not be a job itself, in case of worker crashes.

===

Jira story [#IP-466](https://deliveroo.atlassian.net/browse/IP-466) in project *Infrastructure and Platform*:

> ## Why
> 
> When an dyno crashes, under certain circumstances deliveries can fail to recover.
> 
> ## What
> 
> [~john.tzikas] bumped into this issue. After investigation, it turns out the jobs engine was left in a bad state — the "schedule" job (in charge of promoting deferred jobs) would be left marked as pending.
> 
> Unfortunately this job cannot get scrubbed, because the scrubbing job itself is scheduled.