### PR TITLE
Speedup schedule job

### DIFF
--- a/routemaster.rb
+++ b/routemaster.rb
@@ -26,14 +26,14 @@ module Routemaster
   def self.batch_queue
     @_batch_queue ||= begin
       require 'routemaster/models/queue'
-      Models::Queue['main']
+      Models::Queue::MAIN
     end
   end
 
   def self.aux_queue
     @_aux_queue ||= begin
       require 'routemaster/models/queue'
-      Models::Queue['aux']
+      Models::Queue::AUX
     end
   end
 

--- a/routemaster.rb
+++ b/routemaster.rb
@@ -26,14 +26,14 @@ module Routemaster
   def self.batch_queue
     @_batch_queue ||= begin
       require 'routemaster/models/queue'
-      Models::Queue.new(name: 'main')
+      Models::Queue['main']
     end
   end
 
   def self.aux_queue
     @_aux_queue ||= begin
       require 'routemaster/models/queue'
-      Models::Queue.new(name: 'aux')
+      Models::Queue['aux']
     end
   end
 

--- a/routemaster/models/queue.rb
+++ b/routemaster/models/queue.rb
@@ -163,9 +163,12 @@ module Routemaster
         include Mixins::Redis
         include Enumerable
 
+        # Names of all used queues
+        NAMES = %w[ aux main ]
+
         def each
-          _redis.scan_each(match: 'jobs:index:*') do |k|
-            yield new(name: k.sub(/^jobs:index:/, ''))
+          NAMES.each do |n|
+            yield new(name: n)
           end
         end
       end

--- a/routemaster/models/queue.rb
+++ b/routemaster/models/queue.rb
@@ -166,10 +166,21 @@ module Routemaster
         # Names of all used queues
         NAMES = %w[ aux main ]
 
+        # Accessor for allowed named queues
+        def [](name)
+          raise ArgumentError, "queue name '#{name}' is not valid" unless NAMES.include?(name)
+          new(name: name)
+        end
+
         def each
           NAMES.each do |n|
             yield new(name: n)
           end
+        end
+
+        # Prevent instanciation of queues not in NAMES
+        def self.extended(by)
+          by.private_class_method :new
         end
       end
       extend ClassMethods

--- a/routemaster/models/queue.rb
+++ b/routemaster/models/queue.rb
@@ -163,19 +163,9 @@ module Routemaster
         include Mixins::Redis
         include Enumerable
 
-        # Names of all used queues
-        NAMES = %w[ aux main ]
-
-        # Accessor for allowed named queues
-        def [](name)
-          raise ArgumentError, "queue name '#{name}' is not valid" unless NAMES.include?(name)
-          new(name: name)
-        end
-
-        def each
-          NAMES.each do |n|
-            yield new(name: n)
-          end
+        # Iterate over all known queues
+        def each(&block)
+          [AUX, MAIN].each(&block)
         end
 
         # Prevent instanciation of queues not in NAMES
@@ -185,6 +175,8 @@ module Routemaster
       end
       extend ClassMethods
 
+      AUX  = new(name: 'aux')
+      MAIN = new(name: 'main')
 
       private
 

--- a/routemaster/services/worker.rb
+++ b/routemaster/services/worker.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require 'routemaster/services'
 require 'routemaster/mixins/log_exception'
 require 'routemaster/services/deliver'

--- a/spec/controllers/pulse_spec.rb
+++ b/spec/controllers/pulse_spec.rb
@@ -47,7 +47,7 @@ describe Routemaster::Controllers::Pulse, type: :controller do
       ENV['ROUTEMASTER_SCALING_THRESHOLD'] = '10'
       ENV['ROUTEMASTER_SCALING_THRESHOLD'] = '10'
 
-      Routemaster::Models::Queue.new(name: 'test').tap do |q|
+      Routemaster::Models::Queue.new(name: 'main').tap do |q|
         job_count.times do |idx|
           q.push Routemaster::Models::Job.new(name: 'null', args: idx, run_at: job_deadline)
         end

--- a/spec/controllers/pulse_spec.rb
+++ b/spec/controllers/pulse_spec.rb
@@ -47,7 +47,7 @@ describe Routemaster::Controllers::Pulse, type: :controller do
       ENV['ROUTEMASTER_SCALING_THRESHOLD'] = '10'
       ENV['ROUTEMASTER_SCALING_THRESHOLD'] = '10'
 
-      Routemaster::Models::Queue.new(name: 'main').tap do |q|
+      Routemaster::Models::Queue['main'].tap do |q|
         job_count.times do |idx|
           q.push Routemaster::Models::Job.new(name: 'null', args: idx, run_at: job_deadline)
         end

--- a/spec/controllers/pulse_spec.rb
+++ b/spec/controllers/pulse_spec.rb
@@ -47,7 +47,7 @@ describe Routemaster::Controllers::Pulse, type: :controller do
       ENV['ROUTEMASTER_SCALING_THRESHOLD'] = '10'
       ENV['ROUTEMASTER_SCALING_THRESHOLD'] = '10'
 
-      Routemaster::Models::Queue['main'].tap do |q|
+      Routemaster::Models::Queue::MAIN.tap do |q|
         job_count.times do |idx|
           q.push Routemaster::Models::Job.new(name: 'null', args: idx, run_at: job_deadline)
         end

--- a/spec/jobs/monitor_spec.rb
+++ b/spec/jobs/monitor_spec.rb
@@ -30,7 +30,7 @@ describe Routemaster::Jobs::Monitor do
       Routemaster::Models::Job.new(name: 'null', args: 2, run_at: Routemaster.now + 1000),
       Routemaster::Models::Job.new(name: 'null', args: 3, run_at: Routemaster.now),
     ].each do |j|
-      Routemaster::Models::Queue.new(name: 'foo').push(j)
+      Routemaster::Models::Queue.new(name: 'main').push(j)
     end
   end
 
@@ -42,8 +42,8 @@ describe Routemaster::Jobs::Monitor do
     it { expect(@gauges).to include(['subscriber.queue.events',  12, array_including('subscriber:alice')]) }
     it { expect(@gauges).to include(['subscriber.queue.events',  42, array_including('subscriber:bob')]) }
 
-    it { expect(@gauges).to include(['jobs.count', 2, array_including(%w[queue:foo status:instant])]) }
-    it { expect(@gauges).to include(['jobs.count', 1, array_including(%w[queue:foo status:scheduled])]) }
+    it { expect(@gauges).to include(['jobs.count', 2, array_including(%w[queue:main status:instant])]) }
+    it { expect(@gauges).to include(['jobs.count', 1, array_including(%w[queue:main status:scheduled])]) }
 
     it { expect(@gauges).to include(['redis.bytes_used',    a_kind_of(Fixnum), a_kind_of(Array)]) }
     it { expect(@gauges).to include(['redis.low_mark',      a_kind_of(Fixnum), a_kind_of(Array)]) }

--- a/spec/jobs/monitor_spec.rb
+++ b/spec/jobs/monitor_spec.rb
@@ -30,7 +30,7 @@ describe Routemaster::Jobs::Monitor do
       Routemaster::Models::Job.new(name: 'null', args: 2, run_at: Routemaster.now + 1000),
       Routemaster::Models::Job.new(name: 'null', args: 3, run_at: Routemaster.now),
     ].each do |j|
-      Routemaster::Models::Queue.new(name: 'main').push(j)
+      Routemaster::Models::Queue['main'].push(j)
     end
   end
 

--- a/spec/jobs/monitor_spec.rb
+++ b/spec/jobs/monitor_spec.rb
@@ -30,7 +30,7 @@ describe Routemaster::Jobs::Monitor do
       Routemaster::Models::Job.new(name: 'null', args: 2, run_at: Routemaster.now + 1000),
       Routemaster::Models::Job.new(name: 'null', args: 3, run_at: Routemaster.now),
     ].each do |j|
-      Routemaster::Models::Queue['main'].push(j)
+      Routemaster::Models::Queue::MAIN.push(j)
     end
   end
 

--- a/spec/jobs/scrub_queues_spec.rb
+++ b/spec/jobs/scrub_queues_spec.rb
@@ -8,7 +8,7 @@ require 'routemaster/services/worker'
 
 describe Routemaster::Jobs::ScrubQueues do
 
-  let(:queue) { Routemaster::Models::Queue.new(name: 'main') }
+  let(:queue) { Routemaster::Models::Queue['main'] }
   let(:job) { Routemaster::Models::Job.new(name: 'fail') }
   let(:worker) { Routemaster::Services::Worker.new(id: 'flakey', queue: queue) }
 

--- a/spec/jobs/scrub_queues_spec.rb
+++ b/spec/jobs/scrub_queues_spec.rb
@@ -8,7 +8,7 @@ require 'routemaster/services/worker'
 
 describe Routemaster::Jobs::ScrubQueues do
 
-  let(:queue) { Routemaster::Models::Queue['main'] }
+  let(:queue) { Routemaster::Models::Queue::MAIN }
   let(:job) { Routemaster::Models::Job.new(name: 'fail') }
   let(:worker) { Routemaster::Services::Worker.new(id: 'flakey', queue: queue) }
 

--- a/spec/jobs/scrub_queues_spec.rb
+++ b/spec/jobs/scrub_queues_spec.rb
@@ -8,7 +8,7 @@ require 'routemaster/services/worker'
 
 describe Routemaster::Jobs::ScrubQueues do
 
-  let(:queue) { Routemaster::Models::Queue.new(name: 'foo') }
+  let(:queue) { Routemaster::Models::Queue.new(name: 'main') }
   let(:job) { Routemaster::Models::Job.new(name: 'fail') }
   let(:worker) { Routemaster::Services::Worker.new(id: 'flakey', queue: queue) }
 

--- a/spec/jobs/scrub_workers_spec.rb
+++ b/spec/jobs/scrub_workers_spec.rb
@@ -8,7 +8,7 @@ require 'routemaster/services/worker'
 
 describe Routemaster::Jobs::ScrubWorkers do
 
-  let(:queue) { Routemaster::Models::Queue['main'] }
+  let(:queue) { Routemaster::Models::Queue::MAIN }
   let(:job) { Routemaster::Models::Job.new(name: 'null') }
   let(:worker) { Routemaster::Services::Worker.new(id: 'scrappy', queue: queue) }
 

--- a/spec/jobs/scrub_workers_spec.rb
+++ b/spec/jobs/scrub_workers_spec.rb
@@ -8,7 +8,7 @@ require 'routemaster/services/worker'
 
 describe Routemaster::Jobs::ScrubWorkers do
 
-  let(:queue) { Routemaster::Models::Queue.new(name: 'foo') }
+  let(:queue) { Routemaster::Models::Queue['main'] }
   let(:job) { Routemaster::Models::Job.new(name: 'null') }
   let(:worker) { Routemaster::Services::Worker.new(id: 'scrappy', queue: queue) }
 

--- a/spec/models/queue_spec.rb
+++ b/spec/models/queue_spec.rb
@@ -5,7 +5,7 @@ require 'routemaster/models/queue'
 require 'routemaster/models/job'
 
 describe Routemaster::Models::Queue do
-  subject { described_class.new(name: 'main') }
+  subject { described_class['main'] }
 
   def make_job(x:0, at:nil)
     Routemaster::Models::Job.new(name: 'null', args:x, run_at:at)

--- a/spec/models/queue_spec.rb
+++ b/spec/models/queue_spec.rb
@@ -5,7 +5,7 @@ require 'routemaster/models/queue'
 require 'routemaster/models/job'
 
 describe Routemaster::Models::Queue do
-  subject { described_class['main'] }
+  subject { described_class::MAIN }
 
   def make_job(x:0, at:nil)
     Routemaster::Models::Job.new(name: 'null', args:x, run_at:at)

--- a/spec/services/ingest_spec.rb
+++ b/spec/services/ingest_spec.rb
@@ -19,7 +19,7 @@ module Routemaster
 
     let(:events) {[ make_event, make_event ]}
 
-    let(:queue) { Models::Queue['main'] }
+    let(:queue) { Models::Queue::MAIN }
 
     def perform
       events.each do |event|

--- a/spec/services/ingest_spec.rb
+++ b/spec/services/ingest_spec.rb
@@ -19,7 +19,7 @@ module Routemaster
 
     let(:events) {[ make_event, make_event ]}
 
-    let(:queue) { Models::Queue.new(name: 'main') }
+    let(:queue) { Models::Queue['main'] }
 
     def perform
       events.each do |event|

--- a/spec/services/ticker_spec.rb
+++ b/spec/services/ticker_spec.rb
@@ -4,7 +4,7 @@ require 'routemaster/services/ticker'
 require 'routemaster/models/queue'
 
 describe Routemaster::Services::Ticker do
-  let(:q) { Routemaster::Models::Queue.new(name: 'foo') }
+  let(:q) { Routemaster::Models::Queue['main'] }
   subject { described_class.new queue: q, name: 'tick', every: 42 }
 
   it 'enqueues a job' do

--- a/spec/services/ticker_spec.rb
+++ b/spec/services/ticker_spec.rb
@@ -4,7 +4,7 @@ require 'routemaster/services/ticker'
 require 'routemaster/models/queue'
 
 describe Routemaster::Services::Ticker do
-  let(:q) { Routemaster::Models::Queue['main'] }
+  let(:q) { Routemaster::Models::Queue::MAIN }
   subject { described_class.new queue: q, name: 'tick', every: 42 }
 
   it 'enqueues a job' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,7 @@ require 'simplecov'
 SimpleCov.start
 
 require 'dotenv'
-Dotenv.load!('.env')
-Dotenv.overload('.env.test')
+Dotenv.load!('.env.test', '.env')
 
 require 'pry'
 require 'pry-remote'


### PR DESCRIPTION
This refactors `Queue.each` to list queues from a static list (`Queue::NAMES`) instead of inspecting the database; and for consistency, prevents instantiation of arbitrarily-named queues.

### Why

The "schedule" service promotes deferred jobs to be run ASAP (e.g. when a batch has reached its deadline).

Currently this job scans for all queues, which is expensive (calls `SCAN`) and pointless as the list of queues is not dynamic — 85% of the job duration is scanning, and the service runs every 100ms on each worker, so it's worth optimising.

![](https://www.dropbox.com/s/if56rm3v5ymi0pj/Screenshot%202017-02-08%2010.02.47.png?raw=1) 