### PR TITLE
IP-426: Payloads in events

### DIFF
--- a/.env
+++ b/.env
@@ -74,3 +74,7 @@ ROUTEMASTER_MONITOR_INTERVAL=10
 ROUTEMASTER_SCALING_THRESHOLD=100
 ROUTEMASTER_SCALING_DEADLINE=1000
 
+# maximum number of bytes in an event's optional data payload (when messagepack'ed)
+# DO NOT INCREASE THIS - using the event bus as a data bus is a strong smell of
+# an incompatible architecture, and will cause major bus scalability issues.
+ROUTEMASTER_MAX_EVENT_DATA=64

--- a/.rspec
+++ b/.rspec
@@ -1,5 +1,4 @@
 -I.
 --color
-#--profile
-#--format progress
---format d
+--profile
+--format progress

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,5 @@
 -I.
 --color
---profile
---format progress
+#--profile
+#--format progress
+--format d

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :development do
   gem 'pry-remote'
 
   # testing against the client
-  gem 'routemaster-client'
+  gem 'routemaster-client', path: '../routemaster-client'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :development do
   gem 'pry-remote'
 
   # testing against the client
-  gem 'routemaster-client', path: '../routemaster-client'
+  gem 'routemaster-client', git: 'https://github.com/deliveroo/routemaster-client.git', ref: '1e152c9'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: ../routemaster-client
+  specs:
+    routemaster-client (3.0.0)
+      faraday (>= 0.9.0)
+      oj (~> 2.17)
+      typhoeus (~> 1.1)
+      wisper (~> 1.6.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -83,11 +92,6 @@ GEM
     redis (3.3.3)
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
-    routemaster-client (3.0.0)
-      faraday (>= 0.9.0)
-      oj (~> 2.17)
-      typhoeus (~> 1.1)
-      wisper (~> 1.6.1)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -155,7 +159,7 @@ DEPENDENCIES
   rack-test
   redis
   redis-namespace
-  routemaster-client
+  routemaster-client!
   rspec
   rspec-its
   sentry-raven
@@ -168,4 +172,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-PATH
-  remote: ../routemaster-client
+GIT
+  remote: https://github.com/deliveroo/routemaster-client.git
+  revision: 1e152c9c5a7f724e81df1eb0aee6cea1aef6bf86
+  ref: 1e152c9
   specs:
     routemaster-client (3.0.0)
       faraday (>= 0.9.0)

--- a/README.md
+++ b/README.md
@@ -298,8 +298,10 @@ push to a given topic will see their requests met with errors.
 
     >> POST /topics/:name
     >> {
-    >>   type:  <type>,
-    >>   url:   <url>
+    >>   type:      <string>,
+    >>   url:       <string>,
+    >>   timestamp: <integer>,
+    >>   data:      <anything>
     >> }
 
 `:name` is limited to 32 characters (lowercase letters and the underscore
@@ -313,9 +315,19 @@ application for the first time, a typical use case is to perform an "initial syn
 Given create, update, delete are only sent on changes in the lifecycle of the
 entity, this extra event can be sent for all currently existing entities.
 
-
 `<url>` is the authoritative URL for the entity corresponding to the event
 (maximum 1024 characters, must use HTTPS scheme).
+
+`<timestamp>` (optional) is an integer number of milliseconds since the UNIX
+epoch and represents when the event occured. If unspecified it'll be set by the
+bus on reception.
+
+`<data>` (optional) is discouraged although not deprecated. It is intended when
+the RESN paradigm becomes impractical to implement — e.g. small, very
+frequently-changing representations that can't reasonably be fetched from the
+source and inconvenient to reify as changes in the domain (typically for storage
+reasons).
+
 
 The response is always empty (no body). Possible statuses (besides
 authentication-related):
@@ -373,16 +385,21 @@ Otherwise, they will be resent at the next interval.
     >>
     >> [
     >>   {
-    >>     topic: <name>,
-    >>     type:  <type>,
-    >>     url:   <url>,
-    >>     t:     <t>
+    >>     topic: <string>,
+    >>     type:  <string>,
+    >>     url:   <string>,
+    >>     t:     <integer>,
+    >>     data:  <anything>
     >>   },
     >>   ...
     >> ]
 
-`<t>` is the timestamp at which the event was originally received, in
-milliseconds since the UTC Epoch.
+All fields values are as described when publishing events, with the following
+caveats:
+
+- On delivery, the timestamp field is always present; and named `t` instead of
+  `timestamp`.
+- The `data` field will be omitted if unspecified or null on publication.
 
 Possible response statuses:
 

--- a/routemaster/controllers/topics.rb
+++ b/routemaster/controllers/topics.rb
@@ -44,6 +44,7 @@ module Routemaster
             topic: params['name'],
             type:  data.fetch('type'),
             url:   data.fetch('url'),
+            data:  data.fetch('data', nil),
             timestamp: data['timestamp'] || Routemaster.now
           )
         rescue ArgumentError => e

--- a/routemaster/models/callback_url.rb
+++ b/routemaster/models/callback_url.rb
@@ -8,6 +8,7 @@ module Routemaster
       include Mixins::Assert
 
       def initialize(url)
+        _assert url, 'URL is missing'
         parsed_url = URI.parse(url)
         _assert (parsed_url.scheme == 'https'), 'URL is not HTTPS'
         _assert parsed_url.query.nil?, 'URL has query string'

--- a/routemaster/models/event.rb
+++ b/routemaster/models/event.rb
@@ -30,9 +30,9 @@ module Routemaster
       end
 
       def inspect
-        '<%s %s:%s url="%s">' % [
+        '<%s %s:%s url="%s" data=%s>' % [
           self.class.name.demodulize,
-          @topic, @type, @url, @data,
+          @topic, @type, @url, @data.inspect,
         ]
       end
     end

--- a/routemaster/models/event.rb
+++ b/routemaster/models/event.rb
@@ -18,9 +18,9 @@ module Routemaster
       def initialize(**options)
         super
         @type      = options.fetch(:type, nil)
-        @url       = CallbackURL.new options.fetch(:url, nil)
+        @url       = CallbackURL.new options[:url]
         @topic     = options.fetch(:topic)
-        @data      = EventData.build options.fetch(:data, nil)
+        @data      = EventData.build options[:data]
 
         _assert VALID_TYPES.include?(@type), 'bad event type'
       end

--- a/routemaster/models/event.rb
+++ b/routemaster/models/event.rb
@@ -1,8 +1,9 @@
 require 'routemaster/models'
 require 'routemaster/models/callback_url'
+require 'routemaster/models/event_data'
 require 'routemaster/models/message'
 require 'routemaster/mixins/assert'
-require 'base64'
+require 'core_ext/string'
 
 module Routemaster
   module Models
@@ -12,24 +13,26 @@ module Routemaster
 
       VALID_TYPES = %w(create update delete noop)
 
-      attr_reader :topic, :type, :url
+      attr_reader :topic, :type, :url, :data
 
       def initialize(**options)
         super
-        _assert VALID_TYPES.include?(options[:type]), 'bad event type'
+        @type      = options.fetch(:type, nil)
+        @url       = CallbackURL.new options.fetch(:url, nil)
         @topic     = options.fetch(:topic)
-        @type      = options.fetch(:type)
-        @url       = CallbackURL.new options.fetch(:url)
+        @data      = EventData.build options.fetch(:data, nil)
+
+        _assert VALID_TYPES.include?(@type), 'bad event type'
       end
 
       def to_hash
-        super.merge(topic: @topic, type: @type, url: @url)
+        super.merge(topic: @topic, type: @type, url: @url, data: @data)
       end
 
       def inspect
         '<%s %s:%s url="%s">' % [
           self.class.name.demodulize,
-          @topic, @type, @url,
+          @topic, @type, @url, @data,
         ]
       end
     end

--- a/routemaster/models/event_data.rb
+++ b/routemaster/models/event_data.rb
@@ -1,0 +1,36 @@
+require 'routemaster/models'
+require 'routemaster/mixins/assert'
+require 'msgpack'
+
+module Routemaster
+  module Models
+    # Value object for event data blobs.
+    # Fails on construction if the serialized representation is too long.
+    class EventData < SimpleDelegator
+      include Mixins::Assert
+
+      MAX_EVENT_DATA = ENV.fetch('ROUTEMASTER_MAX_EVENT_DATA').to_i
+
+      class << self
+        private :new
+
+        def build(data)
+          return if data.nil?
+          new(data)
+        end
+      end
+
+      def initialize(data)
+        _assert data.kind_of?(Hash)
+        blob = MessagePack.dump(data)
+        _assert blob.length <= MAX_EVENT_DATA, 'event data too large'
+        super
+      end
+
+      def ==(other)
+        other.kind_of?(self.class) && __getobj__ == other.__getobj__
+      end
+    end
+  end
+end
+

--- a/routemaster/services/deliver.rb
+++ b/routemaster/services/deliver.rb
@@ -75,6 +75,8 @@ module Routemaster
             type:  event.type,
             url:   event.url,
             t:     event.timestamp
+          }.tap { |d|
+            d[:data] = event.data.to_hash if event.data
           }
         end
       end

--- a/routemaster/services/ingest.rb
+++ b/routemaster/services/ingest.rb
@@ -31,6 +31,7 @@ module Routemaster
         end
 
         _counters.incr('events.published', topic: @topic.name)
+        _counters.incr('events.bytes', topic: @topic.name, count: data.length)
         @topic.increment_count
         self
       end

--- a/spec/controllers/topics_spec.rb
+++ b/spec/controllers/topics_spec.rb
@@ -62,6 +62,25 @@ describe Routemaster::Controllers::Topics, type: :controller do
       end
     end
 
+    context 'when supplying a data payload' do
+      let(:event_payload) {{
+        'lat' => 45.1882728, 'lon' => 5.723756
+      }}
+      let(:data) {{
+        type: 'create',
+        url:  'https://example.com/widgets/123',
+        data:  event_payload,
+      }}
+
+      it { expect(perform).to be_ok }
+
+      context 'with too much data' do
+        let(:event_payload) { SecureRandom.hex(32) }
+
+        it { expect(perform).to be_bad_request }
+      end
+    end
+
     describe '(error cases)' do
       it 'returns 400 on bad JSON' do
         payload.replace('whatever')

--- a/spec/integration/delivery_spec.rb
+++ b/spec/integration/delivery_spec.rb
@@ -61,7 +61,7 @@ describe 'Event delivery', type: :acceptance, slow: true do
     5.times do |index|
       client.created('cats', "https://example.com/cats/#{index}")
     end
-    processes.watch.wait_log %r{delivered 5 events}
+    processes.client.wait_log %r{received batch of 5 events}
   end
 
   it 'delivers data payloads' do
@@ -80,7 +80,7 @@ describe 'Event delivery', type: :acceptance, slow: true do
       client.created('cats', "https://example.com/cats/#{index}")
     end
 
-    processes.watch.wait_log %r{delivered 5 events}
+    processes.client.wait_log %r{received batch of 5 events}
   end
 
   it 'emits ingestion metrics' do

--- a/spec/integration/delivery_spec.rb
+++ b/spec/integration/delivery_spec.rb
@@ -64,6 +64,13 @@ describe 'Event delivery', type: :acceptance, slow: true do
     processes.watch.wait_log %r{delivered 5 events}
   end
 
+  it 'delivers data payloads' do
+    subscribe
+    client.created('cats', 'https://example.com/cats/42', data: { 'name' => 'garfield' })
+
+    processes.client.wait_log /^payload: {"name":"garfield"}/
+  end
+
   it 'delivers partial batches after a timeout' do
     max_events.replace '10'
     timeout.replace '1000'

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,7 +2,12 @@ require 'spec_helper'
 require 'routemaster/models/event'
 
 describe Routemaster::Models::Event do
-  let(:options) {{ topic: 'widgets', type: 'create', url: 'https://example.com/widgets/123' }}
+  let(:options) {{
+    topic: 'widgets',
+    type: 'create', 
+    url: 'https://example.com/widgets/123',
+    data: { foo: 1 },
+  }}
   subject { described_class.new(**options) }
 
   describe '#initialize' do
@@ -27,6 +32,11 @@ describe Routemaster::Models::Event do
 
     it 'fails if the URL has a query string' do
       options[:url] = 'https://example.com/widgets/123?wut'
+      expect { subject }.to raise_error(ArgumentError)
+    end
+
+    it 'fails if the data blob if too large' do
+      options[:data] = SecureRandom.hex(33)
       expect { subject }.to raise_error(ArgumentError)
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -35,8 +35,13 @@ describe Routemaster::Models::Event do
       expect { subject }.to raise_error(ArgumentError)
     end
 
-    it 'fails if the data blob if too large' do
-      options[:data] = SecureRandom.hex(33)
+    it 'fails if the data blob is not a hash' do
+      options[:data] = 'foobar'
+      expect { subject }.to raise_error(ArgumentError)
+    end
+
+    it 'fails if the data blob is too large' do
+      options[:data] = { 'foo' => SecureRandom.hex(33) }
       expect { subject }.to raise_error(ArgumentError)
     end
   end

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -105,6 +105,25 @@ describe Routemaster::Services::Deliver do
         expect(events.last['url']).to match(/\/3$/)
       end
 
+      describe 'data payload' do
+        it 'adds :data if a payload is present' do
+          buffer.push Routemaster::Models::Event.new(
+            topic: 'things',
+            type:  'noop',
+            url:   "https://example.com/things/1",
+            data:  { foo: 'bar' })
+          perform
+          events = JSON.parse(@request.body)
+          expect(events.last['data']).to eq('foo' => 'bar')
+        end
+
+        it 'does not add :data when the payload is absent' do
+          perform
+          events = JSON.parse(@request.body)
+          expect(events.last).not_to have_key('data')
+        end
+      end
+
       it_behaves_like 'an event counter', 3, status: 'success'
 
       shared_examples 'failure' do

--- a/spec/services/ingest_spec.rb
+++ b/spec/services/ingest_spec.rb
@@ -69,5 +69,9 @@ module Routemaster
     it 'increments events.published' do
       expect { perform }.to change { get_counter('events.published', topic: 'widgets') }.from(0).to(2)
     end
+
+    it 'increments events.bytes' do
+      expect { perform }.to change { get_counter('events.bytes', topic: 'widgets') }.from(0)
+    end
   end
 end

--- a/spec/support/client.ru
+++ b/spec/support/client.ru
@@ -3,6 +3,7 @@ require 'json'
 
 class Handler
   def on_events(batch)
+    $stderr.puts "received batch of #{batch.length} events"
     batch.each do |event|
       $stderr.puts "received #{event['url']}, #{event['type']}, #{event['topic']}"
       $stderr.puts "payload: #{event['data'].to_json}" if event['data']

--- a/spec/support/client.ru
+++ b/spec/support/client.ru
@@ -1,9 +1,11 @@
 require 'routemaster/receiver'
+require 'json'
 
 class Handler
   def on_events(batch)
     batch.each do |event|
       $stderr.puts "received #{event['url']}, #{event['type']}, #{event['topic']}"
+      $stderr.puts "payload: #{event['data'].to_json}" if event['data']
       $stderr.flush
     end
   end


### PR DESCRIPTION
Adds support for (small!) payloads in events.

Client-side changes are at deliveroo/routemaster-client#16.

-----

Jira story [#IP-426](https://deliveroo.atlassian.net/browse/IP-426) in project *Infrastructure and Platform*:

> ## Why 
> 
> There's a small number of use cases where the "pure RESTful" approach of only sending _events_ on the bus doesn't work (e.g. high-frequency updates where the subscribers might not manage to fetch intermediary representations), and the alternative (storing the history of change on the publisher side) scales very poorly.
> 
> Such an example if the `rider_location` resource, with GPS coordinates changing potentially every 10s.
> 
> ## What
> 
> - Add support for Routemaster to accept and transmit resource representations in JSON form.
> - Amend `routemaster-drain` to cache form the transmitted representations if present (bypassing the API querying).
> - Set a hard limit on representation sizes, defaulting to 64 bytes.