### PR TITLE
fix version of routemaster-client as specified ref is gone

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :development do
   gem 'pry-remote'
 
   # testing against the client
-  gem 'routemaster-client', git: 'https://github.com/deliveroo/routemaster-client.git', ref: '1e152c9'
+  gem 'routemaster-client'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/deliveroo/routemaster-client.git
-  revision: 1e152c9c5a7f724e81df1eb0aee6cea1aef6bf86
-  ref: 1e152c9
-  specs:
-    routemaster-client (3.0.0)
-      faraday (>= 0.9.0)
-      oj (~> 2.17)
-      typhoeus (~> 1.1)
-      wisper (~> 1.6.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -94,6 +83,11 @@ GEM
     redis (3.3.3)
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
+    routemaster-client (3.1.0)
+      faraday (>= 0.9.0)
+      oj (~> 2.17)
+      typhoeus (~> 1.1)
+      wisper (~> 1.6.1)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -161,7 +155,7 @@ DEPENDENCIES
   rack-test
   redis
   redis-namespace
-  routemaster-client!
+  routemaster-client
   rspec
   rspec-its
   sentry-raven


### PR DESCRIPTION
The `ref` is not included in any branch on routemaster-client
anymore (see https://github.com/deliveroo/routemaster-client/commit/1e152c9 ).
I guess there has been a force push? This PR changes it to the version on Rubygems, so `routemaster` can be bundled again.
![screen shot 2017-04-05 at 17 45 26](https://cloud.githubusercontent.com/assets/570608/24716680/b5db8b90-1a27-11e7-821f-e6833636f84b.png)
