### PR TITLE
Force multiple CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.3.3
+  - 2.3.3
 services:
-- redis-server
+  - redis-server
 script:
-- bundle exec rspec --format d
-- bundle exec codeclimate-test-reporter
+  - bundle exec rspec --format d
+  - bundle exec codeclimate-test-reporter
 addons:
-    code_climate:
-        repo_token: bd632b47fe1e702f5e3f39b6a67e60f23e7aaa7194c45dbdf735539800d78d5a
+  code_climate:
+    repo_token: bd632b47fe1e702f5e3f39b6a67e60f23e7aaa7194c45dbdf735539800d78d5a
+env:
+  - CI_RUN_INDEX=0
+  - CI_RUN_INDEX=1
+  - CI_RUN_INDEX=2
+  - CI_RUN_INDEX=3
+  - CI_RUN_INDEX=4


### PR DESCRIPTION
Run the test suite 5 times (in parallel). This is to force us to weed out any flakies — given the concurrency happening in some parts of the test suite, this should help avoid flakyness.