### PR TITLE
SETI-308: Don't report delivery failures as errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,15 @@ Routemaster can send exception traces to a 3rd party by setting the
 For the latter two, you will need to provide the reporting endpoint in
 `EXCEPTION_SERVICE_URL`
 
+Note that event delivery failures will *not* normally be reported to the
+exception service, as they're not errors with Routemaster itself.
+
+To check delivery failures, one can:
+
+- monitor the `routemaster.delivery.batches` metrics with `status:failure`.
+- inspect the logs for `failed to deliver`.
+
+
 ### Autodrop
 
 Routemaster will, by default, permenently drop the oldest messages from queues

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -168,7 +168,7 @@ common: &default_settings
     # To stop specific errors from reporting to New Relic, set this property
     # to comma-separated values.  Default is to ignore routing errors,
     # which are how 404's get triggered.
-    ignore_errors: "ActionController::RoutingError,Sinatra::NotFound"
+    ignore_errors: "ActionController::RoutingError,Sinatra::NotFound,Routemaster::Models::Queue::Retry"
 
   # If you're interested in capturing memcache keys as though they
   # were SQL uncomment this flag. Note that this does increase

--- a/routemaster/mixins/log.rb
+++ b/routemaster/mixins/log.rb
@@ -8,7 +8,7 @@ module Routemaster
       protected
 
       def _log
-        @@_logger ||= Services::Logger.new
+        @@_logger ||= Services::Logger.instance
       end
 
       def _log_exception(e)

--- a/routemaster/services/logger.rb
+++ b/routemaster/services/logger.rb
@@ -1,9 +1,12 @@
 require 'logger'
 require 'delegate'
+require 'singleton'
 
 module Routemaster
   module Services
     class Logger < SimpleDelegator
+      include Singleton
+
       def initialize
         file_path = ENV['ROUTEMASTER_LOG_FILE']
         file = (file_path && File.exist?(file_path)) ? File.open(file_path, 'a') : $stderr

--- a/spec/jobs/batch_spec.rb
+++ b/spec/jobs/batch_spec.rb
@@ -80,6 +80,13 @@ module Routemaster
         it 'increments the attempts counter' do
           expect { perform }.to change { batch.reload.attempts }.from(0).to(1)
         end
+
+        it 'logs the error' do
+          expect(Services::Logger.instance).to receive(:warn) do |&block|
+            expect(block.call).to match /CantDeliver/
+          end
+          perform  
+        end
       end
 
       context 'when subscriber has been removed' do

--- a/spec/services/logger_spec.rb
+++ b/spec/services/logger_spec.rb
@@ -5,8 +5,9 @@ require 'spec/support/env'
 
 module Routemaster
   describe Services::Logger do
+    subject { Class.new(described_class).instance }
 
-    describe '#initialize' do
+    describe '.instance' do
       it 'creates correct instance' do
         expect(subject).to be_a_kind_of(described_class)
       end


### PR DESCRIPTION
- Adds a bit of extra testing
- Configures Routemaster to not report delivery errors to New Relic

===

Jira story [#SETI-308](https://deliveroo.atlassian.net/browse/SETI-308) in project *Software Engineering Tools and Infrastructure*:

> ## Why
> 
> Routemaster reports delivery errors to New Relic.
> This created confusion and can make users mistakenly think there's an issue with Routemaster.
> 
> ## What
> 
> Don't report these exceptions (the monitoring does have enough info).