### PR TITLE
SETI-309: Drop SCAN usage

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -193,6 +193,13 @@ All timestamps are represented as integers, milliseconds since the Unix epoch.
   NB: this is represented as a list so that atomic operations can be used (eg.
   `BRPOPLPUSH`) and no jobs ever get lost.
 
+`jobs:pending:index:{q}` (set)
+
+  A set of worker identifiers, acting as an index for the previous key. Values
+  are exactly the set of possible `{worker}` values above.
+  Added to whenever popping from the queue, removed from only when scrubbing the
+  queue.
+
 `workers` (hash)
 
   Maps worker identifiers to the timestamp they were last

--- a/routemaster/lua/queue_scrub.lua
+++ b/routemaster/lua/queue_scrub.lua
@@ -6,6 +6,9 @@
 -- KEYS[1]: list, the worker queue
 -- KEYS[2]: list, the job queue
 -- KEYS[3]: set,  the job index
+-- KEYS[4]: set,  the queue's worker/pending index
+--
+-- ARGV[1]: the worker ID
 --
 
 local counter = 0
@@ -14,5 +17,8 @@ while true do
   if not item then break end
   counter = counter + 1
 end
+
+redis.call('SREM', KEYS[4], ARGV[1])
+
 return counter
 


### PR DESCRIPTION
When scrubbing queues, don't `SCAN` for the list of temporary per-worker list of processed jobs. Instead refer to an index of know workers for this queue.

NB: usage of SCAN is what caused service degradation a couple weeks back; when the queue length increases (e.g. because of a bad subscriber), scrubbing starts consuming an inordinate amount of Redis time.

===

Jira story [#SETI-309](https://deliveroo.atlassian.net/browse/SETI-309) in project *Software Engineering Tools and Infrastructure*:

> ## Why
> 
> The queue-scrubbing job uses SCAN.
> This degrades under stress as SCAN is `O ( n )` on the keyspace, ie. on the number of queued batches.
> 
> ## What
> 
> Don't use SCAN.
> Prefer relying on a worker index key.
> 
> Take great care with concurrency/worker failure cases :)