### PR TITLE
[SETI-519] Use an official Deliveroo CircleCI helper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: /routemaster
   docker:
-    - image: marcinw/circle:latest
+    - image: deliveroo/circleci:0.1.0
 
 version: 2
 
@@ -17,19 +17,19 @@ jobs:
 
       - run:
           name: Ensure clean slate
-          command: bin/ci down
+          command: ci down
 
       - run:
           name: Build composition
-          command: bin/ci build
+          command: ci build
 
       - run:
           name: Wait for Redis to start
-          command: bin/ci run --rm wait redis:6379
+          command: ci run --rm wait wfi redis:6379
 
       - run:
           name: Run RSpec and report test results
-          command: bin/ci run --rm app bin/test_and_report
+          command: ci run --rm app bin/test_and_report
 
   run_ci_2:
     <<: *test_run

--- a/bin/ci
+++ b/bin/ci
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-
-set -e
-
-docker-compose -f docker-compose.ci.yml $@

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -21,6 +21,6 @@ services:
       - redis
 
   wait:
-    image: dadarek/wait-for-dependencies:0.1
+    image: deliveroo/circleci:0.1.0
     links:
       - redis


### PR DESCRIPTION
This change replaces a temporary Docker image used to build and test on Circle CI with something more robust that we as Deliveroo control.