### PR TITLE
Add support for targetting an event at a particular subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ entity, this extra event can be sent for all currently existing entities.
 (maximum 1024 characters, must use HTTPS scheme).
 
 `<timestamp>` (optional) is an integer number of milliseconds since the UNIX
-epoch and represents when the event occured. If unspecified it'll be set by the
+epoch and represents when the event occurred. If unspecified it'll be set by the
 bus on reception.
 
 `<data>` (optional) is discouraged although not deprecated. It is intended when
@@ -375,6 +375,11 @@ the RESN paradigm becomes impractical to implement — e.g. small, very
 frequently-changing representations that can't reasonably be fetched from the
 source and inconvenient to reify as changes in the domain (typically for storage
 reasons).
+
+`<target>` (optional) If present, the event will only be delivered to the
+subscriber with the given name.  
+The use case for this is when performing an "initial sync" (as described above)
+and we intend to avoid delivering these `noop` events to any other subscriber.
 
 
 The response is always empty (no body). Possible statuses (besides

--- a/routemaster/controllers/topics.rb
+++ b/routemaster/controllers/topics.rb
@@ -52,7 +52,12 @@ module Routemaster
           halt 400, 'bad event'
         end
 
-        Services::Ingest.new(topic: topic, event: event, queue: Routemaster.batch_queue).call
+        Services::Ingest.new(
+          topic: topic,
+          event: event,
+          queue: Routemaster.batch_queue,
+          subscriber_name:  data.fetch('target', nil)
+        ).call
 
         halt :ok
       end

--- a/routemaster/models/subscription.rb
+++ b/routemaster/models/subscription.rb
@@ -47,7 +47,7 @@ module Routemaster
         end
 
         def where(subscriber: nil, topic: nil)
-          _assert(subscriber.nil? ^ topic.nil?, 'exactly one or subscriber or topic must be provided')
+          _assert(subscriber.nil? ^ topic.nil?, 'exactly one of subscriber or topic must be provided')
           if subscriber
             Set.new _redis.smembers(_key_subscriber(subscriber)).map { |name|
               topic = Topic.find(name)


### PR DESCRIPTION
### Why

Currently when backfilling a topic to routemaster, ALL subscribers will receive `:noop` events which can lead to scaling issues.

### What

One of the ways to improve the backfilling practice, is to allow a publisher to target topic events at a particular subscriber.

This PR, introduces an additional option for the payload that is `post`ed to the `/topics` end-point:

- `target`: The name of the subscription to receive the event. -- If missing the event is delivered to ALL subscribers, if invalid (non-existent or not-subscribed-to-the-topic) the event is not delivered to anyone.

### Variations

One could argue that if the target subscriber does not exist or in the case it is not subscribed to receive events of the given `topic`, we should do a `400`.