### PR TITLE
SETI-610: Delete subscription when deleting API token

### DIFF
--- a/routemaster/controllers/api_token.rb
+++ b/routemaster/controllers/api_token.rb
@@ -1,5 +1,6 @@
 require 'routemaster/controllers/base'
 require 'routemaster/models/client_token'
+require 'routemaster/models/subscriber'
 
 module Routemaster
   module Controllers
@@ -28,6 +29,7 @@ module Routemaster
       end
 
       delete '/api_tokens/:token', auth: :root do
+        Models::Subscriber.new(name: params['token']).destroy
         Models::ClientToken.destroy!(token: params['token'])
         halt 204
       end

--- a/spec/controllers/api_token_spec.rb
+++ b/spec/controllers/api_token_spec.rb
@@ -8,20 +8,19 @@ describe Routemaster::Controllers::ApiToken, type: :controller do
   let(:root_key) { ENV['ROUTEMASTER_ROOT_KEY']}
   let(:app) { described_class.new }
 
+  def list_keys
+    basic_authorize root_key, 'x'
+    get '/api_tokens'
+  end
+
+  def create_key
+    basic_authorize root_key, 'x'
+    post '/api_tokens',
+      { 'name' => 'alice' }.to_json,
+      'CONTENT_TYPE' => 'application/json'
+  end
+
   describe '/api_tokens endpoint' do
-
-    let(:list_keys) do
-      basic_authorize root_key, 'x'
-      get '/api_tokens'
-    end
-
-    let(:create_key) do
-      basic_authorize root_key, 'x'
-      post '/api_tokens',
-        { 'name' => 'alice' }.to_json,
-        'CONTENT_TYPE' => 'application/json'
-    end
-
     it 'returns a 204 when no keys exist' do
       list_keys
       expect(last_response.status).to eq(204)
@@ -43,17 +42,46 @@ describe Routemaster::Controllers::ApiToken, type: :controller do
       expect(last_response.status).to eq(200)
       expect(response_body).to include('name' => 'alice', 'token' => anything)
     end
+  end
 
-    it 'can delete key and have an empty list' do
-      create_key
-      new_key = JSON.parse(last_response.body)['token']
+  describe 'DELETE /api_tokens/:token' do
+    def response
       basic_authorize root_key, 'x'
-      delete "/api_tokens/#{new_key}"
-      expect(last_response.status).to eq(204)
-      expect(last_response.body).to be_empty
-      list_keys
-      expect(last_response.status).to eq(204)
-      expect(last_response.body).to be_empty
+      delete "/api_tokens/#{token}"
+      last_response
+    end
+
+    context 'when key does not exist' do
+      let(:token) { 'foobar' }
+
+      it { expect(response.status).to eq 204 }
+    end
+
+    context 'when key exists' do
+      let!(:token) {
+        create_key
+        JSON.parse(last_response.body)['token']
+      }
+
+      it { expect(response.status).to eq 204 }
+
+      it 'removes the key from the list' do
+        expect {
+          response
+        }.to change {
+          list_keys ; last_response.body
+        }.to('')
+      end
+
+      context 'when subscriber exists' do
+        before { Routemaster::Models::Subscriber.new(name: token).save }
+
+        it 'deletes the subscriber' do
+          expect { response }.to change {
+            Routemaster::Models::Subscriber.find(token)&.name
+          }.to(nil)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Whenever an API token gets removed, delete the corresponding subscriber (if it exists).

The rationale is that the introduction of the `rtm` CLI led people to believe that:

```
rtm token del foobar-0000-1111-2222
```

would both delete the token _and_ the subscriber, and as a consequence declog the queues.

===

Jira story [#SETI-610](https://deliveroo.atlassian.net/browse/SETI-610) in project *Software Engineering Tools and Infrastructure*:

> ## Why
> 
> When users remove the API token for a subscriber, they expect the subscription (and its queue) to be deleted with it.
> 
> ## What
> 
> Delete the subscriber (if any) when removing its API token.