### PR TITLE
SETI-641: Don't error on "future timestamps" when events are already queued

### DIFF
--- a/routemaster/controllers/topics.rb
+++ b/routemaster/controllers/topics.rb
@@ -37,6 +37,10 @@ module Routemaster
           halt 400, 'bad event'
         end
 
+        if data['timestamp'] && data['timestamp'] > Routemaster.now
+          halt 400, 'timestamp is in the future'
+        end
+
         begin
           event = Routemaster::Models::Event.new(
             topic: params['name'],

--- a/routemaster/models/event.rb
+++ b/routemaster/models/event.rb
@@ -23,7 +23,6 @@ module Routemaster
         @data      = EventData.build options[:data]
 
         _assert VALID_TYPES.include?(@type), 'bad event type'
-        _assert options[:timestamp].to_i <= Routemaster.now, 'timestamp is from the future'
       end
 
       def to_hash

--- a/spec/controllers/topics_spec.rb
+++ b/spec/controllers/topics_spec.rb
@@ -52,6 +52,19 @@ describe Routemaster::Controllers::Topics, type: :controller do
         perform
         expect(last_response).to be_ok
       end
+
+      context 'when the timestamp is in the future' do
+        let(:data) {{
+          type: 'create',
+          url:  'https://example.com/widgets/123',
+          timestamp: Time.now.to_i * 1e3 + 3_600_000
+        }}
+
+        it 'responds bad request' do
+          perform
+          expect(last_response).to be_bad_request
+        end
+      end
     end
 
     context 'when supplying a null timestamp' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'routemaster/models/event'
+require 'securerandom'
 
 describe Routemaster::Models::Event do
   let(:options) {{
@@ -43,6 +44,11 @@ describe Routemaster::Models::Event do
     it 'fails if the data blob is too large' do
       options[:data] = { 'foo' => SecureRandom.hex(33) }
       expect { subject }.to raise_error(ArgumentError)
+    end
+
+    it 'passes if the timestamp is in the future' do
+      options[:timestamp] = Routemaster.now + 3_600_000
+      expect { subject }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
Reject future timestamps on ingestion but not elsewhere — like when deserialising events just before delivery.

===

Jira story [#SETI-641](https://deliveroo.atlassian.net/browse/SETI-641) in project *Software Engineering Tools and Infrastructure*:

> ## Why
> 
> We reject future timestamps on injection.
> 
> Because our timer isn't monotonic, timestamps can _become_ future on e.g. clock deskewing.
> 
> ## What
> 
> Reject future timestamps on ingestion but not elsewhere.
> 
> Offending backtrace:
> 
>  !image-2017-09-06-15-40-38-714.png|thumbnail! 