### PR TITLE
SETI-611: Allow arbitrary token creation

### DIFF
--- a/routemaster/controllers/api_token.rb
+++ b/routemaster/controllers/api_token.rb
@@ -14,7 +14,7 @@ module Routemaster
 
       post '/api_tokens', auth: :root, parse: :json do
         begin
-          token = Models::ClientToken.create!(name: data['name'])
+          token = Models::ClientToken.create!(name: data['name'], token: data['token'])
         rescue ArgumentError => e
           halt 400, e.message
         end

--- a/routemaster/models/client_token.rb
+++ b/routemaster/models/client_token.rb
@@ -21,6 +21,7 @@ module Routemaster
       def self.create!(name:, token: nil)
         service = User.new(name)
         token ||= '%s--%s' % [service, SecureRandom.hex(16)]
+        token = User.new(token)
         _redis.hset(KEY_BY_TOKEN, token, service)
         token
       end

--- a/routemaster/models/user.rb
+++ b/routemaster/models/user.rb
@@ -8,7 +8,7 @@ module Routemaster
 
       def initialize(str)
         _assert str.kind_of?(String)
-        _assert(str =~ /[a-z0-9:_-]{1,64}/)
+        _assert(str =~ /\A[a-z0-9:_-]{1,64}\Z/)
         super
       end
     end

--- a/routemaster/models/user.rb
+++ b/routemaster/models/user.rb
@@ -7,8 +7,8 @@ module Routemaster
       include Mixins::Assert
 
       def initialize(str)
-        _assert str.kind_of?(String)
-        _assert(str =~ /\A[a-z0-9:_-]{1,64}\Z/)
+        _assert str.kind_of?(String), 'requires a string'
+        _assert(str =~ /\A[a-z0-9:_-]{1,64}\z/, 'contains invalid characters')
         super
       end
     end

--- a/spec/controllers/api_token_spec.rb
+++ b/spec/controllers/api_token_spec.rb
@@ -36,6 +36,16 @@ describe Routemaster::Controllers::ApiToken, type: :controller do
       expect(response_body).to include('name' => 'alice', 'token' => anything)
     end
 
+    it 'can create token with specific value' do
+      basic_authorize root_key, 'x'
+      post '/api_tokens',
+        { name: 'alice', token: 'alice-0000-1111-2222' }.to_json,
+        'CONTENT_TYPE' => 'application/json'
+      expect(last_response.status).to eq(201)
+      response_body = JSON.parse(last_response.body)
+      expect(response_body).to include('name' => 'alice', 'token' => 'alice-0000-1111-2222')
+    end
+
     it 'can list existing tokens' do
       create_key
       list_keys

--- a/spec/models/client_token_spec.rb
+++ b/spec/models/client_token_spec.rb
@@ -5,7 +5,8 @@ require 'spec/support/persistence'
 describe Routemaster::Models::ClientToken do
 
   describe '.create!' do
-    let(:perform) { described_class.create!(name: 'john-mcfoo') }
+    let(:options) {{ name: 'john-mcfoo' }}
+    let(:perform) { described_class.create!(**options) }
 
     it 'passes' do
       expect { perform }.not_to raise_error
@@ -13,6 +14,18 @@ describe Routemaster::Models::ClientToken do
 
     it 'returns a token' do
       expect(perform).to be_a_kind_of(String)
+    end
+
+    context 'with a bad service name' do
+      let(:options) {{ name: 'john <script> mcfoo' }}
+
+      it { expect { perform }.to raise_error(ArgumentError) }
+    end
+
+    context 'with a bad token value' do
+      let(:options) {{ name: 'john-mcfoo', token: 'hax0r <script> token' }}
+
+      it { expect { perform }.to raise_error(ArgumentError) }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'routemaster/models/user'
+
+describe Routemaster::Models::User do
+  shared_examples 'failure' do |title,value|
+    context "with #{title} (#{value.inspect})" do
+      it { expect { described_class.new(value) }.to raise_error(ArgumentError) }
+    end
+  end
+
+  shared_examples 'success' do |title,value|
+    context "with #{title} (#{value.inspect})" do
+      it { expect { described_class.new(value) }.not_to raise_error }
+      it { expect(described_class.new(value)).to eq value }
+    end
+  end
+
+  include_examples 'success', 'a short string', 'foobar'
+  include_examples 'success', 'a service name with UUID', 'foobar--59709301-9bb4-49dd-8d42-74b865c47804'
+
+  include_examples 'failure', 'too long a string', (['foo']*20).join('-')
+  include_examples 'failure', 'trailing newline', "foobar\n"
+  include_examples 'failure', 'non-string', :foobar
+  include_examples 'failure', 'spaces', 'foo bar'
+  include_examples 'failure', 'invalid characters', 'fôøbar'
+end


### PR DESCRIPTION
- Allow the API to receive a specific token value when adding API tokens (instead of just generating new random tokens)
- Properly validates names (subscriber names, topics, tokens) 

===

Jira story [#SETI-611](https://deliveroo.atlassian.net/browse/SETI-611) in project *Software Engineering Tools and Infrastructure*:

> ## Why
> 
> `routemaster-client` expects to be able to pass a custom token along with a service name when creating an API token, but the custom token is ignored.
> 
> ## What
> 
> Honour the passed custom token.