### PR TITLE
SETI-65: Add end-to-end latency monitoring

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -147,7 +147,7 @@ All timestamps are represented as integers, milliseconds since the Unix epoch.
   A list whose first items are:
   - the subscriber token this batch is for,
   - the timestamp at which the batch was created,
-  - unused, reserved.
+  - the number of delivery attempts for this batch,
   followed by the serialized messages to deliver. 
   
   `bid` is the batch's UID.

--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ as well as the following counter metrics:
     - `delivery.time` (sum of delivery times in milliseconds)
     - `delivery.time2` (sum of delivery times squared)
 - latency metrics, tagged by subscriber:
-    - `latency.batches` (number of batch first delivery attempts)
-    - `latency.time.first` (sum of times from batch creation to first delivery attempt)
-    - `latency.time.last` (sum of times from batch creation to successful delivery attempt)
+    - `latency.batches.count` (number of batch first delivery attempts)
+    - `latency.batches.first_attempt` (sum of times from batch creation to first delivery attempt)
+    - `latency.batches.last_attempt` (sum of times from batch creation to successful delivery attempt)
 - `process` (tagged with `status:start` or `:stop`, and `type:web` or
   `:worker`), incremented when processes boot or shut down (cleanly)
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ as well as the following counter metrics:
     - `delivery.batches` (one count per batch)
     - `delivery.time` (sum of delivery times in milliseconds)
     - `delivery.time2` (sum of delivery times squared)
+- latency metrics, tagged by subscriber:
+    - `latency.batches` (number of batch first delivery attempts)
+    - `latency.time.first` (sum of times from batch creation to first delivery attempt)
+    - `latency.time.last` (sum of times from batch creation to successful delivery attempt)
 - `process` (tagged with `status:start` or `:stop`, and `type:web` or
   `:worker`), incremented when processes boot or shut down (cleanly)
 

--- a/routemaster/jobs/batch.rb
+++ b/routemaster/jobs/batch.rb
@@ -21,7 +21,7 @@ module Routemaster
         batch.promote
 
         # handle unsubscription, autodrop
-        unless batch.valid?
+        unless batch.load_and_count&.valid?
           batch.delete
           return self
         end
@@ -33,7 +33,7 @@ module Routemaster
           select { |msg| msg.kind_of?(Models::Event) }
 
         begin
-          @delivery.call(batch.subscriber, events)
+          @delivery.call(batch, events)
           batch.delete
         rescue Exceptions::DeliveryFailure => e
           _log_exception(e)

--- a/routemaster/lua/batch_load_and_count.lua
+++ b/routemaster/lua/batch_load_and_count.lua
@@ -1,0 +1,14 @@
+--		
+-- Increments the attempts counter on a batch and returns all its data.
+--		
+-- KEYS[1]: the batch key		
+--		
+		
+local attempts = redis.call('LINDEX', KEYS[1], 2)
+if not attempts then
+  return nil
+else
+  redis.call('LSET', KEYS[1], 2, tonumber(attempts) + 1)
+  return redis.call('LRANGE', KEYS[1], 0, -1)
+end
+

--- a/routemaster/services/deliver.rb
+++ b/routemaster/services/deliver.rb
@@ -128,13 +128,13 @@ module Routemaster
         _counters.incr('delivery.batches',  queue: @batch.subscriber_name, count: 1,              status: status)
         _counters.incr('delivery.time',     queue: @batch.subscriber_name, count: delivery_time,  status: status)
         _counters.incr('delivery.time2',    queue: @batch.subscriber_name, count: delivery_time2, status: status)
-        _counters.incr('latency.time.last', queue: @batch.subscriber_name, count: latency) if status == 'success'
+        _counters.incr('latency.batches.last_attempt', queue: @batch.subscriber_name, count: latency) if status == 'success'
       end
 
       def _update_pre_counters(latency)
         return unless @batch.attempts == 1
-        _counters.incr('latency.batches',     queue: @batch.subscriber_name, count: 1)
-        _counters.incr('latency.time.first',  queue: @batch.subscriber_name, count: latency)
+        _counters.incr('latency.batches.count',     queue: @batch.subscriber_name, count: 1)
+        _counters.incr('latency.batches.first_attempt',  queue: @batch.subscriber_name, count: latency)
       end
     end
   end

--- a/routemaster/services/deliver.rb
+++ b/routemaster/services/deliver.rb
@@ -21,58 +21,74 @@ module Routemaster
       CONNECT_TIMEOUT = ENV.fetch('ROUTEMASTER_CONNECT_TIMEOUT').to_i
       TIMEOUT         = ENV.fetch('ROUTEMASTER_TIMEOUT').to_i
 
-      def self.call(*args)
-        new(*args).call
+      def self.call(batch, events)
+        new(batch: batch, events: events).call
       end
 
-      def initialize(subscriber, events, throttle_service: Services::Throttle)
-        @subscriber = subscriber
+      def initialize(batch:, events:, throttle_service: Services::Throttle)
+        @batch      = batch
         @buffer     = events
-        @throttle   = throttle_service.new(@subscriber)
+        @throttle   = throttle_service.new(batch.subscriber)
       end
 
       def call
-        _log.debug { "starting delivery to '#{@subscriber.name}'" }
+        _log.debug { "starting delivery to '#{@batch.subscriber_name}'" }
 
-        error = nil
-        status = nil
-        start_at = Routemaster.now
-        begin
-          @throttle.check!(start_at)
-          # send data
-          response = _conn.post do |post|
-            post.headers['Content-Type'] = 'application/json'
-            post.body = Oj.dump(_data, mode: :compat)
-          end
-
-          unless response.success?
-            @throttle.notice_failure
-            error = Exceptions::CantDeliver.new("HTTP #{response.status}", @throttle.retry_backoff)
-          end
-        rescue Exceptions::EarlyThrottle => e
-          status = 'throttled'
-          error = e
-        rescue Faraday::Error::ClientError => e
-          @throttle.notice_failure
-          error = Exceptions::CantDeliver.new("#{e.class.name}: #{e.message}", @throttle.retry_backoff)
-        end
-
-        elapsed = Routemaster.now - start_at
-        status ||= error ? 'failure' : 'success'
-        _update_counters(status, elapsed)
+        status, error = _with_counters { _with_throttle { _do_delivery } }
         
         if error
-          _log.warn { "failed to deliver #{@buffer.length} events to '#{@subscriber.name}'" }
+          _log.warn { "failed to deliver #{@buffer.length} events to '#{@batch.subscriber_name}'" }
           raise error
         else
-          @throttle.notice_success
-          _log.debug { "delivered #{@buffer.length} events to '#{@subscriber.name}'" }
+          _log.debug { "delivered #{@buffer.length} events to '#{@batch.subscriber_name}'" }
         end
         true
       end
 
 
       private
+
+      # wrap a block in counters handling
+      def _with_counters
+        start_at = Routemaster.now
+        latency = @batch.created_at - start_at
+        yield.tap do |status, error|
+          elapsed = Routemaster.now - start_at
+          _update_post_counters(status, elapsed, latency)
+        end
+      end
+
+      # wrap block in a throttle check
+      def _with_throttle
+        @throttle.check!
+        yield.tap do |status, error|
+          case status
+          when 'failure' then @throttle.notice_failure
+          when 'success' then @throttle.notice_success
+          end
+        end
+      rescue Exceptions::EarlyThrottle => e
+        ['throttled', e]
+      end
+
+      # return status and exception if any
+      def _do_delivery
+        # send data
+        response = _conn.post do |post|
+          post.headers['Content-Type'] = 'application/json'
+          post.body = Oj.dump(_data, mode: :compat)
+        end
+
+        if response.success?
+          ['success', nil]
+        else
+          error = Exceptions::CantDeliver.new("HTTP #{response.status}", @throttle.retry_backoff)
+          ['failure', error]
+        end
+      rescue Faraday::Error::ClientError => e
+        error = Exceptions::CantDeliver.new("#{e.class.name}: #{e.message}", @throttle.retry_backoff)
+        ['failure', error]
+      end
 
 
       # assemble data
@@ -91,9 +107,9 @@ module Routemaster
 
 
       def _conn
-        @_conn ||= Faraday.new(@subscriber.callback, ssl: { verify: _verify_ssl? }) do |c|
+        @_conn ||= Faraday.new(@batch.subscriber.callback, ssl: { verify: _verify_ssl? }) do |c|
           c.adapter :typhoeus
-          c.basic_auth(@subscriber.uuid, 'x')
+          c.basic_auth(@batch.subscriber.uuid, 'x')
           c.options.open_timeout = CONNECT_TIMEOUT
           c.options.timeout      = TIMEOUT
         end
@@ -105,11 +121,13 @@ module Routemaster
       end
 
 
-      def _update_counters(status, t)
-        _counters.incr('delivery.events',  queue: @subscriber.name, count: _data.length, status: status)
-        _counters.incr('delivery.batches', queue: @subscriber.name, count: 1,            status: status)
-        _counters.incr('delivery.time',    queue: @subscriber.name, count: t,            status: status)
-        _counters.incr('delivery.time2',   queue: @subscriber.name, count: t*t,          status: status)
+      def _update_post_counters(status, delivery_time, latency)
+        delivery_time2 = delivery_time * delivery_time
+        _counters.incr('delivery.events',   queue: @batch.subscriber_name, count: _data.length,  status: status)
+        _counters.incr('delivery.batches',  queue: @batch.subscriber_name, count: 1,             status: status)
+        _counters.incr('delivery.time',     queue: @batch.subscriber_name, count: delivery_time, status: status)
+        _counters.incr('delivery.time2',    queue: @batch.subscriber_name, count: delivery_time, status: status)
+      end
       end
     end
   end

--- a/routemaster/services/throttle.rb
+++ b/routemaster/services/throttle.rb
@@ -19,7 +19,7 @@ module Routemaster
       end
 
 
-      def check!(current_time)
+      def check!(current_time = Routemaster.now)
         if delay = _halt_with_backoff?
           raise Exceptions::EarlyThrottle.new(delay, @subscriber.name)
         else

--- a/spec/jobs/batch_spec.rb
+++ b/spec/jobs/batch_spec.rb
@@ -44,8 +44,8 @@ module Routemaster
       it { expect { perform }.not_to change { @error } }
 
       it 'attempts delivery' do
-        expect(delivery).to receive(:call) do |sub,ev|
-          expect(sub).to eq(subscriber)
+        expect(delivery).to receive(:call) do |b,ev|
+          expect(b.uid).to eq(batch.uid)
           expect(ev).to eq(messages)
         end
         perform

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -207,6 +207,31 @@ describe Routemaster::Models::Batch do
   end
 
 
+  describe '#load_and_count' do
+    subject { do_ingest(2) }
+
+    it 'increments #attempts' do
+      expect { 
+        subject.load_and_count
+      }.to change {
+        subject.reload.attempts
+      }.by(1)
+    end
+
+    it 'returns the batch' do
+      expect(subject.load_and_count).to eq(subject)
+    end
+
+    context 'when the batch does not exist' do
+      before { subject.delete }
+      it 'is nil' do
+        expect(subject.load_and_count).to be_nil
+      end
+    end
+  end
+
+
+
   describe '#length' do
     subject { do_ingest(2) }
     let(:result) { subject.reload.length }

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -5,6 +5,8 @@ require 'spec/support/webmock'
 require 'spec/support/counters'
 require 'routemaster/services/deliver'
 require 'routemaster/models/subscriber'
+require 'routemaster/models/batch'
+require 'routemaster/services/codec'
 
 describe Routemaster::Services::Deliver do
   let(:buffer) { Array.new }
@@ -19,13 +21,23 @@ describe Routemaster::Services::Deliver do
       }
     ).save
   end
+
+  let(:batch) do
+    buffer.map { |event|
+      Routemaster::Models::Batch.ingest(
+        subscriber: subscriber,
+        timestamp:  event.timestamp,
+        data:       Routemaster::Services::Codec.new.dump(event))
+    }.last
+  end
+
   def reloaded_subscriber
     Routemaster::Models::Subscriber.new(name: subscriber.name)
   end
 
   let(:callback) { 'https://alice.com/widgets' }
 
-  subject { described_class.new(subscriber, buffer) }
+  subject { described_class.new(batch: batch, events: buffer) }
 
   before do
     WebMock.enable!
@@ -112,7 +124,7 @@ describe Routemaster::Services::Deliver do
         allow(throttle_klass).to receive(:new).with(subscriber).and_return(throttle)
       end
 
-      subject { described_class.new(subscriber, buffer, throttle_service: throttle_klass) }
+      subject { described_class.new(batch: batch, events: buffer, throttle_service: throttle_klass) }
 
       context 'when the throttler says that it is OK to deliver to the subscriber' do
         before do
@@ -158,6 +170,12 @@ describe Routemaster::Services::Deliver do
 
 
     context 'when there are no events' do
+      before {
+        buffer << make_event
+        batch
+        buffer.clear
+      }
+
       it 'passes' do
         expect { perform }.not_to raise_error
       end
@@ -173,6 +191,7 @@ describe Routemaster::Services::Deliver do
     end
 
     context 'when there are events' do
+
       before do
         3.times { buffer.push make_event }
       end

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -83,28 +83,28 @@ describe Routemaster::Services::Deliver do
         # double check preconditions
         it { perform rescue nil ; expect(batch.attempts).to eq 1 }
 
-        it 'increments latency.batches counter' do
+        it 'increments latency.batches.count counter' do
           expect { perform rescue nil }.to change {
-            get_counter('latency.batches', { queue: 'alice' })
+            get_counter('latency.batches.count', { queue: 'alice' })
           }.by(1)
         end
 
-        it 'increments latency.time.first counter' do
+        it 'increments latency.batches.first_attempt counter' do
           expect { perform rescue nil }.to change {
-            get_counter('latency.time.first', { queue: 'alice' })
+            get_counter('latency.batches.first_attempt', { queue: 'alice' })
           }
         end
 
         if options[:status] == 'success'
-          it 'increments latency.time.last counter' do
+          it 'increments latency.batches.last_attempt counter' do
             expect { perform rescue nil }.to change {
-              get_counter('latency.time.last', { queue: 'alice' })
+              get_counter('latency.batches.last_attempt', { queue: 'alice' })
             }
           end
         else
-          it 'does not change latency.time.last counter' do
+          it 'does not change latency.batches.last_attempt counter' do
             expect { perform rescue nil }.not_to change {
-              get_counter('latency.time.last', { queue: 'alice' })
+              get_counter('latency.batches.last_attempt', { queue: 'alice' })
             }
           end
         end
@@ -116,28 +116,28 @@ describe Routemaster::Services::Deliver do
         # double check preconditions
         it { perform rescue nil ; expect(batch.attempts).to eq 2 }
 
-        it 'does not change latency.batches counter' do
+        it 'does not change latency.batches.count counter' do
           expect { perform rescue nil }.not_to change {
-            get_counter('latency.batches', { queue: 'alice' })
+            get_counter('latency.batches.count', { queue: 'alice' })
           }
         end
 
-        it 'does not increment latency.time.first counter' do
+        it 'does not increment latency.batches.first_attempt counter' do
           expect { perform rescue nil }.not_to change {
-            get_counter('latency.time.first', { queue: 'alice' })
+            get_counter('latency.batches.first_attempt', { queue: 'alice' })
           }
         end
       end
 
       unless options[:no_timer]
         it 'increments delivery.time counter' do
-          expect { perform rescue nil }.to change { 
+          expect { perform rescue nil }.to change {
             get_counter('delivery.time', tag.merge(queue: 'alice'))
           }
         end
 
         it 'increments delivery.time counter' do
-          expect { perform rescue nil }.to change { 
+          expect { perform rescue nil }.to change {
             get_counter('delivery.time2', tag.merge(queue: 'alice'))
           }
         end
@@ -146,7 +146,7 @@ describe Routemaster::Services::Deliver do
 
     shared_examples 'a delivery failure' do |options|
       options ||= {}
-      
+ 
       it "raises a Routemaster::Exceptions::DeliveryFailure exception" do
         expect { perform }.to raise_error(Routemaster::Exceptions::DeliveryFailure)
       end


### PR DESCRIPTION
This adds the ability to measure:

- Average time from batch creation to first delivery attempt, per subscriber ("bus latency")
- Average time from batch creation to _successful_ delivery attempt, per subscriber ("actual latency", ie. factoring in retries on subscriber failures).

(these exclude the time spent actually sending the batch over HTTP)

In normal operation, we'd expect both values to be equal - and lower than the "timeout" value provided by subscribers.

===

Jira story [#SETI-65](https://deliveroo.atlassian.net/browse/SETI-65) in project *Software Engineering Tools and Infrastructure*:

> Why
> 
> Subscribers monitor this, but it'd be great to monitor how well we're honouring the SLA.
> 
> What
> 
> Use the batch creation timestamp to monitoring "end-to-end" latency, ie. from creation to completion of the first delivery _attempt_ for a given batch.