### PR TITLE
LOG-1870: Routemaster responsibility is not to validate events in the future

### DIFF
--- a/routemaster/controllers/topics.rb
+++ b/routemaster/controllers/topics.rb
@@ -37,10 +37,6 @@ module Routemaster
           halt 400, 'bad event'
         end
 
-        if data['timestamp'] && data['timestamp'] > Routemaster.now
-          halt 400, 'timestamp is in the future'
-        end
-
         begin
           event = Routemaster::Models::Event.new(
             topic: params['name'],

--- a/spec/controllers/topics_spec.rb
+++ b/spec/controllers/topics_spec.rb
@@ -52,19 +52,6 @@ describe Routemaster::Controllers::Topics, type: :controller do
         perform
         expect(last_response).to be_ok
       end
-
-      context 'when the timestamp is in the future' do
-        let(:data) {{
-          type: 'create',
-          url:  'https://example.com/widgets/123',
-          timestamp: Time.now.to_i * 1e3 + 3_600_000
-        }}
-
-        it 'responds bad request' do
-          perform
-          expect(last_response).to be_bad_request
-        end
-      end
     end
 
     context 'when supplying a null timestamp' do
@@ -77,19 +64,6 @@ describe Routemaster::Controllers::Topics, type: :controller do
       it 'responds ok' do
         perform
         expect(last_response).to be_ok
-      end
-    end
-
-    context 'when supplying a future timestamp' do
-      let(:data) {{
-        type: 'create',
-        url:  'https://example.com/widgets/123',
-        timestamp: (Time.now.to_i * 1e3) + 5000
-      }}
-
-      it 'returns 400' do
-        perform
-        expect(last_response.status).to eq(400)
       end
     end
 
@@ -197,7 +171,7 @@ describe Routemaster::Controllers::Topics, type: :controller do
       end
 
       it 'deletes the topic' do
-        expect { perform }.to change { 
+        expect { perform }.to change {
           Routemaster::Models::Topic.find(topic_name)&.name
         }.to(nil)
       end


### PR DESCRIPTION


===

Jira story [#LOG-1870](https://deliveroo.atlassian.net/browse/LOG-1870) in project *Logistics*:

> Sporadically Routemaster will ignore events being sent by publishers if timestamps are in future compared to _Routemaster.now_ time, even if they differ by 1 ms.
> 
> Here are 2 things:
> * Routemaster shouldn't really validate this as its not its responsibility to handle time constrains
> * Its publishers responsibility to ensure being good citizens of the bus