### PR TITLE
Prepare web worker for AWS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,20 +81,22 @@ filter_tests: &filter_tests
     branches:
       ignore:
       - sandbox
+      - ecs_sandbox
       - staging
+      - ecs_staging
       - production
 
 filter_sandbox: &filter_sandbox
   filters:
     branches:
       only:
-      - sandbox
+      - ecs_sandbox
 
 filter_staging: &filter_staging
   filters:
     branches:
       only:
-      - staging
+      - ecs_staging
 
 filter_production: &filter_production
   filters:

--- a/routemaster/application.rb
+++ b/routemaster/application.rb
@@ -1,6 +1,5 @@
 require 'routemaster'
 require 'sinatra'
-require 'rack/ssl'
 require 'routemaster/controllers/pulse'
 require 'routemaster/controllers/topics'
 require 'routemaster/controllers/health'
@@ -18,7 +17,11 @@ module Routemaster
       set :raise_errors, false
     end
 
-    use Rack::SSL
+    if ENV.fetch('FORCE_SSL', 'true') =~ /YES|TRUE|ON|1/i
+      require 'rack/ssl'
+      use Rack::SSL
+    end
+
     use Controllers::Health
     use Controllers::ApiToken
     use Controllers::Pulse

--- a/routemaster/controllers/health.rb
+++ b/routemaster/controllers/health.rb
@@ -3,9 +3,20 @@ require 'routemaster/controllers/base'
 module Routemaster
   module Controllers
     class Health < Base
+      get %r{^/health$}, auth: :none do
+        content_type :json
+        ping.to_json
+      end
+
       get %r{^/health/ping(|.json)$}, auth: :none do
         content_type :json
-        { pong: Time.now }.to_json
+        ping.to_json
+      end
+
+      private
+
+      def ping
+        { pong: Time.now }
       end
     end
   end


### PR DESCRIPTION
This PR adds a `/health` endpoint that does the same thing as `/health/ping` to make ALB health checks work. It also adds a toggle for disabling HTTPS which is not supported between ALBs and EC2 instances.