### PR TITLE
Add instructions to get a local routemaster using docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,3 +579,11 @@ If you want to get a shell on a Docker container built from this image, build th
 ```bash
 docker run --rm -it routemaster sh
 ```
+
+To run routemaster locally with docker-compose, run:
+
+```bash
+docker-compose up
+```
+
+This will spin up redis, the routemaster background worker and the routemaster web worker on port 3000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+
+services:
+
+  redis:
+    image: redis:3.2.9
+
+  web:
+    build:
+      context: .
+    command: bundle exec puma -I . -C config/puma.rb
+    environment:
+      - FORCE_SSL=false
+      - ROUTEMASTER_REDIS_URL=redis://redis:6379/0
+      - PORT=3000
+      - PUMA_BOOT_TIMEOUT=5
+      - PUMA_TIMEOUT=5
+      - PUMA_THREADS=1
+      - PUMA_WORKERS=1
+    links:
+      - redis
+    ports:
+      - "3000:3000"
+
+  worker:
+    build:
+      context: .
+    command: bundle exec bin/worker
+    environment:
+      - ROUTEMASTER_REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
@jeffreylo Is providing a `docker-compose` enough for your use case?

You still need to build the docker image locally, but the build itself is self contained.

#118 