### PR TITLE
PRODENG-XXX: return all subscription attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,9 +501,11 @@ Routermaster provides monitoring endpoints:
     >> GET /subscriptions
     << [
     <<   {
-    <<     subscriber: <username>,
-    <<     callback:   <url>,
-    <<     topics:     [<name>, ...],
+    <<     subscriber:  <username>,
+    <<     callback:    <url>,
+    <<     max_events:  <value>,
+    <<     timeout:     <value>,
+    <<     topics:      [<name>, ...],
     <<     events: {
     <<       sent:       <sent_count>,
     <<       queued:     <queue_size>,

--- a/routemaster/controllers/subscriber.rb
+++ b/routemaster/controllers/subscriber.rb
@@ -96,6 +96,8 @@ module Routemaster
           {
             subscriber: subscriber.name,
             callback: subscriber.callback,
+            max_events: subscriber.max_events,
+            timeout: subscriber.timeout,
             topics: subscriber.topics.map(&:name),
             events: {
               sent:   nil,

--- a/spec/controllers/subscriber_spec.rb
+++ b/spec/controllers/subscriber_spec.rb
@@ -48,6 +48,8 @@ describe Routemaster::Controllers::Subscriber, type: :controller do
         .to eql([{
           "subscriber" => "charlie",
           "callback"   => nil,
+          "max_events" => 100,
+          "timeout"    => 500,
           "topics"     => ["widgets"],
           "events"     => {
             "sent"   => nil,


### PR DESCRIPTION
This PR ensures that the output of `rtm sub list` from [routemaster-client](https://github.com/deliveroo/routemaster-client) gem.