### PR TITLE
SRE-XXX: report multiple app names to New Relic

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -42,7 +42,10 @@ common: &default_settings
   #       - Ajax Service
   #       - All Services
   #
-  app_name: <%= ENV["NEW_RELIC_APP_NAME"] || "Routemaster (#{ENV.fetch('RACK_ENV', 'development')})" %>
+  <% base_app_name = ENV["NEW_RELIC_APP_NAME"] || "Routemaster (#{ENV.fetch('RACK_ENV', 'development')})" %>
+  <% task_app_name = ENV.key?("HOPPER_SERVICE_NAME") ? "#{base_app_name} - #{ENV['HOPPER_SERVICE_NAME']}" : nil %>
+  <% full_app_name = [task_app_name, base_app_name].compact.join(";") %>
+  app_name: '<%= full_app_name %>'
 
   # When "true", the agent collects performance data about your
   # application and reports this data to the New Relic service at

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -42,7 +42,7 @@ common: &default_settings
   #       - Ajax Service
   #       - All Services
   #
-  <% base_app_name = ENV["NEW_RELIC_APP_NAME"] || "Routemaster (#{ENV.fetch('RACK_ENV', 'development')})" %>
+  <% base_app_name = ENV["BASE_NEW_RELIC_APP_NAME"] || "Routemaster (#{ENV.fetch('RACK_ENV', 'development')})" %>
   <% task_app_name = ENV.key?("HOPPER_SERVICE_NAME") ? "#{base_app_name} - #{ENV['HOPPER_SERVICE_NAME']}" : nil %>
   <% full_app_name = [task_app_name, base_app_name].compact.join(";") %>
   app_name: '<%= full_app_name %>'

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -66,13 +66,13 @@ describe Routemaster::Services::Deliver do
       tag = { status: options.fetch(:status) }
 
       it 'increments delivery.events counter' do
-        expect { perform rescue nil }.to change { 
+        expect { perform rescue nil }.to change {
           get_counter('delivery.events', tag.merge(queue: 'alice'))
         }.by(count)
       end
 
       it 'increments delivery.batches counter' do
-        expect { perform rescue nil }.to change { 
+        expect { perform rescue nil }.to change {
           get_counter('delivery.batches', tag.merge(queue: 'alice'))
         }.by(1)
       end
@@ -83,11 +83,12 @@ describe Routemaster::Services::Deliver do
         # double check preconditions
         it { perform rescue nil ; expect(batch.attempts).to eq 1 }
 
-        it 'increments latency.batches.count counter' do
-          expect { perform rescue nil }.to change {
-            get_counter('latency.batches.count', { queue: 'alice' })
-          }.by(1)
-        end
+        # commenting out a flakey while we figure this out:
+        ## it 'increments latency.batches.count counter' do
+        ##   expect { perform rescue nil }.to change {
+        ##     get_counter('latency.batches.count', { queue: 'alice' })
+        ##   }.by(1)
+        ## end
 
         it 'increments latency.batches.first_attempt counter' do
           expect { perform rescue nil }.to change {
@@ -146,7 +147,7 @@ describe Routemaster::Services::Deliver do
 
     shared_examples 'a delivery failure' do |options|
       options ||= {}
- 
+
       it "raises a Routemaster::Exceptions::DeliveryFailure exception" do
         expect { perform }.to raise_error(Routemaster::Exceptions::DeliveryFailure)
       end
@@ -188,7 +189,7 @@ describe Routemaster::Services::Deliver do
         end
 
         it 'increments delivery.batches counter, reporting the batch as successful' do
-          expect { perform rescue nil }.to change { 
+          expect { perform rescue nil }.to change {
             get_counter('delivery.batches', {queue: 'alice', status: "success"})
           }.by(1)
         end
@@ -213,7 +214,7 @@ describe Routemaster::Services::Deliver do
         end
 
         it 'increments delivery.batches counter, reporting the batch as throttled' do
-          expect { perform rescue nil }.to change { 
+          expect { perform rescue nil }.to change {
             get_counter('delivery.batches', {queue: 'alice', status: "throttled"})
           }.by(1)
         end
@@ -264,7 +265,7 @@ describe Routemaster::Services::Deliver do
       it 'sends valid JSON' do
         perform
         expect(@request.headers['Content-Type']).to eq('application/json')
-        expect { JSON.parse(@request.body) }.not_to raise_error 
+        expect { JSON.parse(@request.body) }.not_to raise_error
       end
 
       it 'delivers events in order' do

--- a/spec/services/deliver_spec.rb
+++ b/spec/services/deliver_spec.rb
@@ -83,12 +83,11 @@ describe Routemaster::Services::Deliver do
         # double check preconditions
         it { perform rescue nil ; expect(batch.attempts).to eq 1 }
 
-        # commenting out a flakey while we figure this out:
-        ## it 'increments latency.batches.count counter' do
-        ##   expect { perform rescue nil }.to change {
-        ##     get_counter('latency.batches.count', { queue: 'alice' })
-        ##   }.by(1)
-        ## end
+        it 'increments latency.batches.count counter' do
+          expect { perform rescue nil }.to change {
+            get_counter('latency.batches.count', { queue: 'alice' })
+          }.by(1)
+        end
 
         it 'increments latency.batches.first_attempt counter' do
           expect { perform rescue nil }.to change {


### PR DESCRIPTION
To view the stats of each Hopper service on New Relic separately.

This is useful especially when we have multiple services that are
running different data stores.