### PR TITLE
deliveroo-local: use local-only Dockerfile

### DIFF
--- a/.deliveroo-local/.gitignore
+++ b/.deliveroo-local/.gitignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/.deliveroo-local/Makefile
+++ b/.deliveroo-local/Makefile
@@ -5,8 +5,23 @@ compose = docker-compose -p $(project) -f ../docker-compose.yml -f docker-compos
 
 all: build start
 
-build:
+build: build/docker
 	@$(compose) build
+
+build/docker:
+	@sh ./make/generate-dockerfile.sh
+
+clean:
+	@$(compose) down
+
+destroy:
+	@$(compose) down -v --rmi=local --remove-orphans
+
+logs:
+	@$(compose) logs -f app worker
+
+restart:
+	@$(compose) up -d
 
 start:
 	@$(compose) up -d

--- a/.deliveroo-local/docker-compose.yml
+++ b/.deliveroo-local/docker-compose.yml
@@ -3,9 +3,12 @@ version: "3.6"
 services:
 
   web:
+    build:
+      context: ./
+      dockerfile: .deliveroo-local/Dockerfile
     command: foreman start --env /dev/null web
     env_file: .deliveroo-local/.env
-    image: deliveroo-local/routemaster
+    image: deliveroo-local/routemaster:latest
     labels:
       - "traefik.docker.network=deliveroo-dns"
       - "traefik.frontend.rule=Host:routemaster.deliveroo-local.com"
@@ -16,19 +19,23 @@ services:
       - 172.177.0.99
 
   worker:
+    build:
+      context: ./
+      dockerfile: .deliveroo-local/Dockerfile
     command: foreman start --env /dev/null worker
-    image: deliveroo-local/routemaster
+    image: deliveroo-local/routemaster:latest
     env_file: .deliveroo-local/.env
-    restart: on-failure
     networks:
       dns:
     dns:
       - 172.177.0.99
 
   test:
-    build: ./
+    build:
+      context: ./
+      dockerfile: .deliveroo-local/Dockerfile
     command: "true"
-    image: deliveroo-local/routemaster
+    image: deliveroo-local/routemaster:latest
     depends_on:
       - redis
     env_file: .deliveroo-local/.env.test

--- a/.deliveroo-local/make/generate-dockerfile.sh
+++ b/.deliveroo-local/make/generate-dockerfile.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This script generates a Dockerfile adds deliveroo-local-certs to the base
+# Dockerfile. Ideally, we'd push out a base Routemaster image and fork from
+# there.
+
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+localdir="$( cd "${dir}/.." && pwd )"
+app="$( cd "${dir}/../../" && pwd )"
+
+# Add the certs image.
+cat << "EOF" > ${localdir}/Dockerfile
+FROM deliveroo/deliveroo-local-certs:latest as dev-certs
+EOF
+
+# List images.
+echo "$(head -n2 ${app}/Dockerfile)" >> ${localdir}/Dockerfile
+
+# Add certs.
+cat << "EOF" >> ${localdir}/Dockerfile
+
+# Copy the certs from the deliveroo-local-ca image.
+COPY --from=dev-certs \
+     /usr/share/ca-certificates/deliveroo-local-ca.crt \
+     /usr/share/ca-certificates/deliveroo-local-ca.crt
+
+# Add the ca-cert to the store.
+RUN echo "deliveroo-local-ca.crt" >> /etc/ca-certificates.conf && \
+    update-ca-certificates --fresh
+EOF
+
+# Include the rest of the Dockerfile.
+echo "$(tail -n +3 ${app}/Dockerfile)" >> ${localdir}/Dockerfile


### PR DESCRIPTION
This patch generates a Dockerfile that includes the deliveroo-local-ca certs.