### PR TITLE
prevent UUIDs from being reported to Datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,14 @@ Note that both endpoints require authentication.
 
 ### Authentication, security.
 
+Note that is _preferable_ for all tokens to be prefixed with owning service
+and double hyphen. For example:
+
+- `publishing-service-one--UUID1234XXX`
+- `subscribing-service-one--UUID1234XXX`
+
+Following that format of tokens will help ensure proper reporting of metrics.
+
 All requests over non-SSL connections will be met with a 308 Permanent Redirect.
 
 HTTP Basic is required for all requests. The password will be ignored, and the

--- a/routemaster/services/ingest.rb
+++ b/routemaster/services/ingest.rb
@@ -13,6 +13,8 @@ module Routemaster
 
     class Ingest
       DEFAULT_PUBLISHER_TAG = 'null'.freeze
+      MALFORMED_PUBLISHER_TAG = 'malformed'.freeze
+      PUBLISHER_NAME_UUID_SEPARATOR = '--'.freeze
 
       include Mixins::Assert
       include Mixins::Counters
@@ -23,12 +25,12 @@ module Routemaster
         @topic = topic
         @event = event
         @queue = queue
+        @publisher = extract_publisher_name
       end
 
       def call
         trace_with_newrelic('Custom/Services/ingest') do
           data = Services::Codec.new.dump(@event)
-          publisher = @topic.publisher.to_s.split('--').first || DEFAULT_PUBLISHER_TAG
 
           @topic.subscribers.each do |s|
             trace_with_newrelic("Custom/Services/ingest-#{s.name}") do
@@ -52,8 +54,8 @@ module Routemaster
             end
           end
 
-          _counters.incr('events.published', topic: @topic.name, publisher: publisher)
-          _counters.incr('events.bytes', topic: @topic.name, count: data.length, publisher: publisher)
+          _counters.incr('events.published', topic: @topic.name, publisher: @publisher)
+          _counters.incr('events.bytes', topic: @topic.name, count: data.length, publisher: @publisher)
 
           trace_with_newrelic('Custom/Services/topic-increment') do
             @topic.increment_count
@@ -61,6 +63,14 @@ module Routemaster
         end
 
         self
+      end
+
+      private
+
+      def extract_publisher_name
+        return DEFAULT_PUBLISHER_TAG unless @topic.publisher
+        return MALFORMED_PUBLISHER_TAG unless @topic.publisher.include?(PUBLISHER_NAME_UUID_SEPARATOR)
+        @topic.publisher.split(PUBLISHER_NAME_UUID_SEPARATOR).first
       end
     end
   end

--- a/spec/services/ingest_spec.rb
+++ b/spec/services/ingest_spec.rb
@@ -76,14 +76,28 @@ module Routemaster
     end
 
     context 'when publisher details exist' do
-      let(:publisher) { 'pub-app--1d44d-6d00-48ee-a404-6d24a73' }
+      context 'publisher name respect separator format' do
+        let(:publisher) { 'pub-app--1d44d-6d00-48ee-a404-6d24a73' }
 
-      it 'increments events.published' do
-        expect { perform }.to change { get_counter('events.published', topic: 'widgets', publisher: 'pub-app') }.from(0).to(2)
+        it 'increments events.published' do
+          expect { perform }.to change { get_counter('events.published', topic: 'widgets', publisher: 'pub-app') }.from(0).to(2)
+        end
+
+        it 'increments events.bytes' do
+          expect { perform }.to change { get_counter('events.bytes', topic: 'widgets', publisher: 'pub-app') }.from(0)
+        end
       end
 
-      it 'increments events.bytes' do
-        expect { perform }.to change { get_counter('events.bytes', topic: 'widgets', publisher: 'pub-app') }.from(0)
+      context 'publisher name does not respect separator format' do
+        let(:publisher) { 'pub-app-1d44d-6d00-48ee-a404-6d24a73' }
+
+        it 'increments events.published' do
+          expect { perform }.to change { get_counter('events.published', topic: 'widgets', publisher: 'malformed') }.from(0).to(2)
+        end
+
+        it 'increments events.bytes' do
+          expect { perform }.to change { get_counter('events.bytes', topic: 'widgets', publisher: 'malformed') }.from(0)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR ensures that when a publisher's token doesn't have the
expected separator in its name, its entire token isn't posted to
Datadog.

Additionally, the README file has been updated to highlight that
tokens with the "--" separator are preferred.