### PR TITLE
include subscribers' UUID when requesting subscription list

### DIFF
--- a/routemaster/controllers/subscriber.rb
+++ b/routemaster/controllers/subscriber.rb
@@ -95,6 +95,7 @@ module Routemaster
         payload = Models::Subscriber.map do |subscriber|
           {
             subscriber: subscriber.name,
+            uuid: subscriber.uuid,
             callback: subscriber.callback,
             max_events: subscriber.max_events,
             timeout: subscriber.timeout,

--- a/routemaster/controllers/subscriber.rb
+++ b/routemaster/controllers/subscriber.rb
@@ -79,7 +79,10 @@ module Routemaster
       # [
       #   {
       #     subscriber: <username>,
+      #     uuid: <uuid>,
       #     callback:   <url>,
+      #     max_events: <max_events>,
+      #     timeout: <timeout>,
       #     topics:     [<name>, ...],
       #     events: {
       #       sent:       <sent_count>,

--- a/spec/controllers/subscriber_spec.rb
+++ b/spec/controllers/subscriber_spec.rb
@@ -9,9 +9,10 @@ require 'json'
 describe Routemaster::Controllers::Subscriber, type: :controller do
   let(:uid) { 'charlie' }
   let(:app) { described_class.new }
+  let(:attributes) { nil }
 
   let(:subscriber) do
-    Routemaster::Models::Subscriber.new(name: 'charlie').save
+    Routemaster::Models::Subscriber.new(name: 'charlie', attributes: attributes).save
   end
 
   let(:topic) do
@@ -28,6 +29,8 @@ describe Routemaster::Controllers::Subscriber, type: :controller do
 
   describe 'GET /subscribers' do
     let(:perform) { get "/subscribers" }
+    let(:uuid) { "subscriber-one--12345678" }
+    let(:attributes) { { uuid: uuid } }
 
     it 'responds' do
       perform
@@ -47,6 +50,7 @@ describe Routemaster::Controllers::Subscriber, type: :controller do
       expect(resp)
         .to eql([{
           "subscriber" => "charlie",
+          "uuid"       => uuid,
           "callback"   => nil,
           "max_events" => 100,
           "timeout"    => 500,


### PR DESCRIPTION
This is necessary when wanting to copy subscribers from one Routemaster instance to another through API calls.