### PR TITLE
docker: always update RubyGems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd -d /home/$ARG_USER -m --shell /bin/false --user-group $ARG_USER
 RUN apt-get update && apt-get install -q -y --no-install-recommends build-essential git \
     dnsutils tcpdump mtr-tiny
 
-RUN gem install bundler
+RUN gem update --system && gem install bundler
 
 WORKDIR $ARG_HOME
 ADD vendor $ARG_HOME/vendor

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -4,7 +4,8 @@ FROM ruby:2.3.3-alpine
 ARG ARG_HOME=/app
 ARG ARG_USER=app
 
-RUN gem install bundler \
+RUN gem update --system \
+    && gem install bundler \
     && apk add --no-cache build-base git \
     && addgroup -S $ARG_USER \
     && adduser -S -D -h /home/$ARG_USER -G $ARG_USER $ARG_USER


### PR DESCRIPTION
Bundler 2.0 (released Jan 3, 2019:
https://bundler.io/blog/2019/01/03/announcing-bundler-2.html) requires
RubyGems >= 3.0.0.

This fixes the following error when building the image:

```
bundler requires RubyGems version >= 3.0.0. Try 'gem update --system' to
update RubyGems itself.
```