### PR TITLE
Fix Broken Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,13 @@ RUN useradd -d /home/$ARG_USER -m --shell /bin/false --user-group $ARG_USER
 
 RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now archived
 
-RUN apt-get update && apt-get install -q -y -V --no-install-recommends build-essential git \
-    dnsutils tcpdump mtr-tiny
+RUN apt-get update \
+    && apt-get install -q -y -V --no-install-recommends \
+        build-essential \
+        dnsutils \
+        git \
+        mtr-tiny \
+        tcpdump
 
 RUN gem install bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ ARG ARG_USER=app
 
 RUN useradd -d /home/$ARG_USER -m --shell /bin/false --user-group $ARG_USER
 
-RUN apt-get update && apt-get install -q -y --no-install-recommends build-essential git \
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now archived
+
+RUN apt-get update && apt-get install -q -y -V --no-install-recommends build-essential git \
     dnsutils tcpdump mtr-tiny
 
 RUN gem install bundler

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -6,7 +6,9 @@ ARG ARG_USER=app
 
 RUN useradd -d /home/$ARG_USER -m --shell /bin/false --user-group $ARG_USER
 
-RUN apt-get update && apt-get install -q -y --no-install-recommends build-essential git
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now archived
+
+RUN apt-get update && apt-get install -q -y -V --no-install-recommends build-essential git
 
 RUN gem install bundler
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,7 +8,10 @@ RUN useradd -d /home/$ARG_USER -m --shell /bin/false --user-group $ARG_USER
 
 RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now archived
 
-RUN apt-get update && apt-get install -q -y -V --no-install-recommends build-essential git
+RUN apt-get update \
+    && apt-get install -q -y -V --no-install-recommends \
+        build-essential \
+        git
 
 RUN gem install bundler
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,13 +1,14 @@
-FROM ruby:2.3.3-alpine
+FROM ruby:2.3.3
 
 # App home directory and app user can be injected through build params.
 ARG ARG_HOME=/app
 ARG ARG_USER=app
 
-RUN gem install bundler \
-    && apk add --no-cache build-base git \
-    && addgroup -S $ARG_USER \
-    && adduser -S -D -h /home/$ARG_USER -G $ARG_USER $ARG_USER
+RUN useradd -d /home/$ARG_USER -m --shell /bin/false --user-group $ARG_USER
+
+RUN apt-get update && apt-get install -q -y --no-install-recommends build-essential git
+
+RUN gem install bundler
 
 WORKDIR $ARG_HOME
 ADD vendor $ARG_HOME/vendor


### PR DESCRIPTION
Due to upstream debian changes the ruby source containers were not working.
Move to using debian-based ruby docker image for tests to be consistent with image used for builds.